### PR TITLE
[Test] Repository 구현체 테스트용 XCTest 코드 작성

### DIFF
--- a/TIG.xcodeproj/project.pbxproj
+++ b/TIG.xcodeproj/project.pbxproj
@@ -20,6 +20,13 @@
 			remoteGlobalIDString = 359369E12C759AEB00BE24FF;
 			remoteInfo = TIGWidgetExtension;
 		};
+		35E93E4D2D5DBB0E008B1C2D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 57A98EFC2C3CCAB600863BC6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57A98F032C3CCAB600863BC6;
+			remoteInfo = TIG;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -40,6 +47,7 @@
 		359369E22C759AEB00BE24FF /* TIGWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TIGWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		359369E42C759AEB00BE24FF /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		359369E62C759AEB00BE24FF /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		35E93E492D5DBB0E008B1C2D /* TIGTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TIGTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A98F042C3CCAB600863BC6 /* TIG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TIG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -72,6 +80,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		35E93E4A2D5DBB0E008B1C2D /* TIGTests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TIGTests; sourceTree = "<group>"; };
 		572B954F2D422B640085A18E /* TIGWidget */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (572B95542D422B640085A18E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TIGWidget; sourceTree = "<group>"; };
 		572B959A2D422B8E0085A18E /* TIG */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (572B95E42D422B8E0085A18E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 572B95E52D422B8E0085A18E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TIG; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -83,6 +92,13 @@
 			files = (
 				359369E72C759AEB00BE24FF /* SwiftUI.framework in Frameworks */,
 				359369E52C759AEB00BE24FF /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35E93E462D5DBB0E008B1C2D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -110,6 +126,7 @@
 			children = (
 				572B959A2D422B8E0085A18E /* TIG */,
 				572B954F2D422B640085A18E /* TIGWidget */,
+				35E93E4A2D5DBB0E008B1C2D /* TIGTests */,
 				359369E32C759AEB00BE24FF /* Frameworks */,
 				57A98F052C3CCAB600863BC6 /* Products */,
 			);
@@ -122,6 +139,7 @@
 			children = (
 				57A98F042C3CCAB600863BC6 /* TIG.app */,
 				359369E22C759AEB00BE24FF /* TIGWidgetExtension.appex */,
+				35E93E492D5DBB0E008B1C2D /* TIGTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -148,6 +166,29 @@
 			productName = TIGWidgetExtension;
 			productReference = 359369E22C759AEB00BE24FF /* TIGWidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
+		};
+		35E93E482D5DBB0E008B1C2D /* TIGTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 35E93E4F2D5DBB0E008B1C2D /* Build configuration list for PBXNativeTarget "TIGTests" */;
+			buildPhases = (
+				35E93E452D5DBB0E008B1C2D /* Sources */,
+				35E93E462D5DBB0E008B1C2D /* Frameworks */,
+				35E93E472D5DBB0E008B1C2D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				35E93E4E2D5DBB0E008B1C2D /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				35E93E4A2D5DBB0E008B1C2D /* TIGTests */,
+			);
+			name = TIGTests;
+			packageProductDependencies = (
+			);
+			productName = TIGTests;
+			productReference = 35E93E492D5DBB0E008B1C2D /* TIGTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		57A98F032C3CCAB600863BC6 /* TIG */ = {
 			isa = PBXNativeTarget;
@@ -178,11 +219,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1540;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1540;
 				TargetAttributes = {
 					359369E12C759AEB00BE24FF = {
 						CreatedOnToolsVersion = 15.4;
+					};
+					35E93E482D5DBB0E008B1C2D = {
+						CreatedOnToolsVersion = 16.0;
+						TestTargetID = 57A98F032C3CCAB600863BC6;
 					};
 					57A98F032C3CCAB600863BC6 = {
 						CreatedOnToolsVersion = 15.4;
@@ -204,12 +249,20 @@
 			targets = (
 				57A98F032C3CCAB600863BC6 /* TIG */,
 				359369E12C759AEB00BE24FF /* TIGWidgetExtension */,
+				35E93E482D5DBB0E008B1C2D /* TIGTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		359369E02C759AEB00BE24FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35E93E472D5DBB0E008B1C2D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -233,6 +286,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		35E93E452D5DBB0E008B1C2D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		57A98F002C3CCAB600863BC6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -247,6 +307,11 @@
 			isa = PBXTargetDependency;
 			target = 359369E12C759AEB00BE24FF /* TIGWidgetExtension */;
 			targetProxy = 359369F02C759AEC00BE24FF /* PBXContainerItemProxy */;
+		};
+		35E93E4E2D5DBB0E008B1C2D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57A98F032C3CCAB600863BC6 /* TIG */;
+			targetProxy = 35E93E4D2D5DBB0E008B1C2D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -321,6 +386,44 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+		35E93E502D5DBB0E008B1C2D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C3P52YR8KJ;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = shin.TIGTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TIG.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TIG";
+			};
+			name = Debug;
+		};
+		35E93E512D5DBB0E008B1C2D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = C3P52YR8KJ;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = shin.TIGTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TIG.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/TIG";
 			};
 			name = Release;
 		};
@@ -539,6 +642,15 @@
 			buildConfigurations = (
 				359369F42C759AEC00BE24FF /* Debug */,
 				359369F52C759AEC00BE24FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		35E93E4F2D5DBB0E008B1C2D /* Build configuration list for PBXNativeTarget "TIGTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				35E93E502D5DBB0E008B1C2D /* Debug */,
+				35E93E512D5DBB0E008B1C2D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TIG.xcodeproj/xcshareddata/xcschemes/TIGWidgetExtension.xcscheme
+++ b/TIG.xcodeproj/xcshareddata/xcschemes/TIGWidgetExtension.xcscheme
@@ -44,6 +44,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "35E93E482D5DBB0E008B1C2D"
+               BuildableName = "TIGTests.xctest"
+               BlueprintName = "TIGTests"
+               ReferencedContainer = "container:TIG.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/TIG/Sources/Model/Entity/DailySchedule.swift
+++ b/TIG/Sources/Model/Entity/DailySchedule.swift
@@ -7,20 +7,7 @@
 
 import Foundation
 
-struct DailySchedule {
+struct DailySchedule: Equatable {
   var date: Date
   var timeSlots: [TimeSlot]
-}
-
-struct ComparableDailySchedule: Equatable {
-  var date: Date
-  var timeSlots: [ComparableTimeSlot]
-}
-
-// timeSlot id 값을 제외하고 비교할 수 있게 해주는 속성
-extension DailySchedule {
-  var comparable: ComparableDailySchedule {
-    let comparableTimeSlots = timeSlots.map { $0.comparable }
-    return ComparableDailySchedule(date: date, timeSlots: comparableTimeSlots)
-  }
 }

--- a/TIG/Sources/Model/Entity/DailySchedule.swift
+++ b/TIG/Sources/Model/Entity/DailySchedule.swift
@@ -11,4 +11,16 @@ struct DailySchedule {
   var date: Date
   var timeSlots: [TimeSlot]
 }
-  
+
+struct ComparableDailySchedule: Equatable {
+  var date: Date
+  var timeSlots: [ComparableTimeSlot]
+}
+
+// timeSlot id 값을 제외하고 비교할 수 있게 해주는 속성
+extension DailySchedule {
+  var comparable: ComparableDailySchedule {
+    let comparableTimeSlots = timeSlots.map { $0.comparable }
+    return ComparableDailySchedule(date: date, timeSlots: comparableTimeSlots)
+  }
+}

--- a/TIG/Sources/Model/Entity/TimeSlot.swift
+++ b/TIG/Sources/Model/Entity/TimeSlot.swift
@@ -13,3 +13,15 @@ struct TimeSlot {
   var end: Int
   var isAvailable: Bool
 }
+
+struct ComparableTimeSlot: Equatable {
+  var start: Int
+  var end: Int
+  var isAvailable: Bool
+}
+
+extension TimeSlot {
+  var comparable: ComparableTimeSlot {
+    ComparableTimeSlot(start: start, end: end, isAvailable: isAvailable)
+  }
+}

--- a/TIG/Sources/Model/Entity/TimeSlot.swift
+++ b/TIG/Sources/Model/Entity/TimeSlot.swift
@@ -7,21 +7,15 @@
 
 import Foundation
 
-struct TimeSlot {
+struct TimeSlot: Equatable {
   var id: String = UUID().uuidString
   var start: Int
   var end: Int
   var isAvailable: Bool
-}
-
-struct ComparableTimeSlot: Equatable {
-  var start: Int
-  var end: Int
-  var isAvailable: Bool
-}
-
-extension TimeSlot {
-  var comparable: ComparableTimeSlot {
-    ComparableTimeSlot(start: start, end: end, isAvailable: isAvailable)
+  
+  static func == (lhs: TimeSlot, rhs: TimeSlot) -> Bool {
+      return lhs.start == rhs.start &&
+             lhs.end == rhs.end &&
+             lhs.isAvailable == rhs.isAvailable
   }
 }

--- a/TIG/Sources/Model/Entity/WeeklySchedule.swift
+++ b/TIG/Sources/Model/Entity/WeeklySchedule.swift
@@ -7,23 +7,7 @@
 
 import Foundation
 
-struct WeeklySchedule {
+struct WeeklySchedule: Equatable {
   var day: WeekDay
   var timeSlots: [TimeSlot]
-}
-
-struct ComparableWeeklySchedule: Equatable {
-  var day: WeekDay
-  var comparableTimeSlots: [ComparableTimeSlot]
-}
-
-// timeSlot id 값을 제외하고 비교할 수 있게 해주는 속성
-extension WeeklySchedule {
-  var comparable: ComparableWeeklySchedule {
-    let comparableTimeSlots = timeSlots.map { $0.comparable }
-    return ComparableWeeklySchedule(
-      day: day,
-      comparableTimeSlots: comparableTimeSlots
-    )
-  }
 }

--- a/TIG/Sources/Model/Entity/WeeklySchedule.swift
+++ b/TIG/Sources/Model/Entity/WeeklySchedule.swift
@@ -12,7 +12,7 @@ struct WeeklySchedule {
   var timeSlots: [TimeSlot]
 }
 
-struct ComparableWeeklySchedule {
+struct ComparableWeeklySchedule: Equatable {
   var day: WeekDay
   var comparableTimeSlots: [ComparableTimeSlot]
 }

--- a/TIG/Sources/Model/Entity/WeeklySchedule.swift
+++ b/TIG/Sources/Model/Entity/WeeklySchedule.swift
@@ -11,3 +11,19 @@ struct WeeklySchedule {
   var day: WeekDay
   var timeSlots: [TimeSlot]
 }
+
+struct ComparableWeeklySchedule {
+  var day: WeekDay
+  var comparableTimeSlots: [ComparableTimeSlot]
+}
+
+// timeSlot id 값을 제외하고 비교할 수 있게 해주는 속성
+extension WeeklySchedule {
+  var comparable: ComparableWeeklySchedule {
+    let comparableTimeSlots = timeSlots.map { $0.comparable }
+    return ComparableWeeklySchedule(
+      day: day,
+      comparableTimeSlots: comparableTimeSlots
+    )
+  }
+}

--- a/TIG/Sources/Repository/Impl/AppConfigRepositoryImpl.swift
+++ b/TIG/Sources/Repository/Impl/AppConfigRepositoryImpl.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftData
 
 final class AppConfigRepositoryImpl: AppConfigRepository {
-
+  
   
   private let modelContext: ModelContext
   
@@ -21,12 +21,20 @@ final class AppConfigRepositoryImpl: AppConfigRepository {
   func setOnboardingCompleted(wakeupTime: Int, bedTime: Int) {
     print("Impl:", #function)
     
-    let model = AppConfigDTO(
-      wakeupTime: wakeupTime,
-      bedTime: bedTime,
-      isOnboarding: true
-    )
-    modelContext.insert(model)
+    let result = getAppConfig()
+    switch result {
+    case .success:
+      print(SwiftDataError.modelAlreadyExist)
+    case .failure(.modelNotFound):
+      let model = AppConfigDTO(
+        wakeupTime: wakeupTime,
+        bedTime: bedTime,
+        isOnboarding: true
+      )
+      modelContext.insert(model)
+    case .failure(let error):
+      print(error)
+    }
   }
   
   
@@ -44,8 +52,8 @@ final class AppConfigRepositoryImpl: AppConfigRepository {
       return .failure(error)
     }
   }
-
-
+  
+  
   func updateWakeupTime(_ time: Int) {
     print("Impl:", #function)
     
@@ -57,7 +65,7 @@ final class AppConfigRepositoryImpl: AppConfigRepository {
       print(error)
     }
   }
-
+  
   
   func fetchWakeupTime() -> Result<Int, any Error> {
     print("Impl:", #function)
@@ -70,7 +78,7 @@ final class AppConfigRepositoryImpl: AppConfigRepository {
       return .failure(error)
     }
   }
-
+  
   
   func updateBedTime(_ time: Int) {
     print("Impl:", #function)
@@ -83,7 +91,7 @@ final class AppConfigRepositoryImpl: AppConfigRepository {
       print(error)
     }
   }
-
+  
   
   func fetchBedTime() -> Result<Int, any Error> {
     print("Impl:", #function)

--- a/TIG/Sources/Repository/Impl/DailyScheduleRepositoryImpl.swift
+++ b/TIG/Sources/Repository/Impl/DailyScheduleRepositoryImpl.swift
@@ -20,8 +20,16 @@ final class DailyScheduleRepositoryImpl: DailyScheduleRepository {
   func createDailySchedule(_ dailySchedule: DailySchedule) {
     print("Impl:", #function)
     
-    let model = DailyScheduleDTO(dailySchedule)
-    modelContext.insert(model)
+    let result = findDailySchedule(dailySchedule)
+    switch result {
+    case .success:
+      print(SwiftDataError.modelAlreadyExist)
+    case .failure(.modelNotFound):
+      let model = DailyScheduleDTO(dailySchedule)
+      modelContext.insert(model)
+    case .failure(let error):
+      print(error)
+    }
   }
 
   

--- a/TIG/Sources/Repository/Impl/WeeklyScheduleRepositoryImpl.swift
+++ b/TIG/Sources/Repository/Impl/WeeklyScheduleRepositoryImpl.swift
@@ -20,9 +20,24 @@ final class WeeklyScheduleRepositoryImpl: WeeklyScheduleRepository {
   func initializeWeeklySchedules() {
     print("Impl:", #function)
     
-    (1...7).forEach {
-      let model = WeeklyScheduleDTO(day: $0, timeSlots: [])
-      modelContext.insert(model)
+    let descriptor = FetchDescriptor<WeeklyScheduleDTO>()
+    
+    do {
+      let datas = try modelContext.fetch(descriptor)
+      
+      guard datas.isEmpty
+      else {
+        print(SwiftDataError.modelAlreadyExist)
+        return
+      }
+      
+      (1...7).forEach {
+        let model = WeeklyScheduleDTO(day: $0, timeSlots: [])
+        modelContext.insert(model)
+      }
+      
+    } catch {
+      print(error)
     }
   }
 

--- a/TIG/Sources/Repository/Impl/WeeklyScheduleRepositoryImpl.swift
+++ b/TIG/Sources/Repository/Impl/WeeklyScheduleRepositoryImpl.swift
@@ -31,8 +31,8 @@ final class WeeklyScheduleRepositoryImpl: WeeklyScheduleRepository {
         return
       }
       
-      (1...7).forEach {
-        let model = WeeklyScheduleDTO(day: $0, timeSlots: [])
+      WeekDay.allCases.forEach {
+        let model = WeeklyScheduleDTO(day: $0.rawValue, timeSlots: [])
         modelContext.insert(model)
       }
       

--- a/TIG/Sources/Repository/Storage/SwiftDataStorage.swift
+++ b/TIG/Sources/Repository/Storage/SwiftDataStorage.swift
@@ -33,6 +33,7 @@ enum SwiftDataError: LocalizedError {
   case fetchError
   case deleteError
   case modelNotFound
+  case modelAlreadyExist
   
   var errorDescription: String {
     switch self {
@@ -42,6 +43,8 @@ enum SwiftDataError: LocalizedError {
       "Delete error"
     case .modelNotFound:
       "Model not found"
+    case .modelAlreadyExist:
+      "Model already exist"
     }
   }
 }

--- a/TIGTests/TIGTests.swift
+++ b/TIGTests/TIGTests.swift
@@ -47,6 +47,7 @@ final class TIGTests: XCTestCase {
     // 1. 온보딩 완료 설정 및 초기 값 검증
     let initialWakeupTime = 1
     let initialBedTime = 1
+    
     appConfigRepository.setOnboardingCompleted(
       wakeupTime: initialWakeupTime,
       bedTime: initialBedTime
@@ -81,6 +82,7 @@ final class TIGTests: XCTestCase {
     
     // 3. 기상 시간 업데이트 후 검증
     let mockWakeupTime = 20
+    
     appConfigRepository.updateWakeupTime(mockWakeupTime)
     let wakeupTimeFetchResultUpdated = appConfigRepository.fetchWakeupTime()
     switch wakeupTimeFetchResultUpdated {
@@ -92,6 +94,7 @@ final class TIGTests: XCTestCase {
     
     // 4. 취침 시간 업데이트 후 검증
     let mockBedTime = 30
+    
     appConfigRepository.updateBedTime(mockBedTime)
     let bedTimeFetchResultUpdated = appConfigRepository.fetchBedTime()
     switch bedTimeFetchResultUpdated {
@@ -102,9 +105,128 @@ final class TIGTests: XCTestCase {
     }
   }
   
-  // MARK: - AppConfigRepository 테스트
+  // MARK: - DailyScheduleRepository 테스트
   func testDailyScheduleRepository() throws {
+    guard let dailyScheduleRepository = dailyScheduleRepository else {
+      XCTFail("appConfigRepository가 nil입니다.")
+      return
+    }
     
+    // 1. DailySchedule 생성
+    let today = Date()
+    var mokDailySchedule = DailySchedule(
+      date: today,
+      timeSlots: [TimeSlot(start: 1, end: 1, isAvailable: true)]
+    )
+    
+    dailyScheduleRepository.createDailySchedule(mokDailySchedule)
+    
+    // 2. DailySchedule 확인
+    let fetchResultInitial = dailyScheduleRepository.fetchDailySchedule(date: today)
+    switch fetchResultInitial {
+    case .success(let data):
+      guard let data = data else {
+        XCTFail("DailySchedule이 nil 입니다.")
+        return
+      }
+      XCTAssertEqual(mokDailySchedule.comparable, data.comparable, "DailySchedule이 일치하지 않습니다.")
+      
+    case .failure(let error):
+      XCTFail("fetch DailySchedule 실패: \(error)")
+    }
+    
+    // 3. DailySchedule 업데이트
+    let mokTimeSlots = [
+      TimeSlot(start: 1, end: 1, isAvailable: true),
+      TimeSlot(start: 2, end: 2, isAvailable: true)
+    ]
+    dailyScheduleRepository.updateDailySchedule(
+      dailySchedule: mokDailySchedule,
+      timeSlots: mokTimeSlots
+    )
+    
+    // 4. 업데이트 된 DailySchedule 확인
+    mokDailySchedule.timeSlots = mokTimeSlots
+    
+    let fetchResult = dailyScheduleRepository.fetchDailySchedule(date: today)
+    switch fetchResult {
+    case .success(let data):
+      guard let data = data else {
+        XCTFail("DailySchedule이 nil 입니다.")
+        return
+      }
+      XCTAssertEqual(
+        mokDailySchedule.comparable,
+        data.comparable,
+        "DailySchedule이 일치하지 않습니다."
+      )
+    case .failure(let error):
+      XCTFail("fetch DailySchedule 실패: \(error)")
+    }
+    
+    // 5. 모든 dailySchedule 확인
+    let allFetchResult = dailyScheduleRepository.fetchAllDailySchedules()
+    switch allFetchResult {
+    case .success(let datas):
+      print(datas)
+    case .failure(let error):
+      XCTFail("fetch All DailySchedules 실패: \(error)")
+    }
   }
   
+  // MARK: - WeeklyScheduleRepository 테스트
+  func testWeeklyScheduleRepository() throws {
+    guard let weeklyScheduleRepository = weeklyScheduleRepository else {
+      XCTFail("weeklyScheduleRepository가 nil입니다.")
+      return
+    }
+    
+    var allWeeklySchedules: [ComparableWeeklySchedule] = []
+    
+    // 1. WeeklySchedules 초기화
+    weeklyScheduleRepository.initializeWeeklySchedules()
+    
+    // 2. WeeklySchedule 업데이트 및 확인
+    WeekDay.allCases.forEach { weekDay in
+      let mokWeeklySchedule = WeeklySchedule(
+        day: weekDay,
+        timeSlots: [TimeSlot(start: 1, end: 1, isAvailable: true)]
+      )
+      allWeeklySchedules.append(mokWeeklySchedule.comparable)
+      
+      weeklyScheduleRepository.updateWeeklySchedule(
+        weeklySchedule: mokWeeklySchedule,
+        timeSlots: mokWeeklySchedule.timeSlots
+      )
+      
+      let fetchResult = weeklyScheduleRepository.fetchWeeklySchedule(
+        weekDay: weekDay
+      )
+      switch fetchResult {
+      case .success(let data):
+        guard let data = data else {
+          XCTFail("\(weekDay)의 WeeklySchedule이 nil 입니다.")
+          return
+        }
+        XCTAssertEqual(
+          mokWeeklySchedule.comparable,
+          data.comparable,
+          "\(weekDay)의 WeeklySchedule이 일치하지 않습니다."
+        )
+      case .failure(let error):
+        XCTFail("\(weekDay)의 fetch WeeklySchedule 실패: \(error)")
+      }
+    }
+    
+    // 5. 모든 weeklySchedules 확인
+    let allFetchResult = weeklyScheduleRepository.fetchAllWeeklySchedules()
+    switch allFetchResult {
+    case .success(let datas):
+      let comparableDatas = datas.map { $0.comparable }
+      XCTAssertEqual(comparableDatas, allWeeklySchedules, "All WeeklySchedule이 일치하지 않습니다.")
+    case .failure(let error):
+      XCTFail("fetch All WeeklySchedules 실패: \(error)")
+    }
+  }
 }
+

--- a/TIGTests/TIGTests.swift
+++ b/TIGTests/TIGTests.swift
@@ -34,6 +34,8 @@ final class TIGTests: XCTestCase {
     weeklyScheduleRepository = nil
     try super.tearDownWithError()
   }
+  
+  
   // MARK: - AppConfigRepository 테스트
   func testAppConfigRepository() throws {
     
@@ -100,6 +102,9 @@ final class TIGTests: XCTestCase {
     }
   }
   
-  
+  // MARK: - AppConfigRepository 테스트
+  func testDailyScheduleRepository() throws {
+    
+  }
   
 }

--- a/TIGTests/TIGTests.swift
+++ b/TIGTests/TIGTests.swift
@@ -9,5 +9,97 @@ import XCTest
 @testable import TIG
 
 final class TIGTests: XCTestCase {
-
+  
+  var appConfigRepository: AppConfigRepository?
+  var dailyScheduleRepository: DailyScheduleRepository?
+  var weeklyScheduleRepository: WeeklyScheduleRepository?
+  
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+    let testSwiftDataStorage = SwiftDataStorage()
+    appConfigRepository = AppConfigRepositoryImpl(
+      modelContext: testSwiftDataStorage.modelContext
+    )
+    dailyScheduleRepository = DailyScheduleRepositoryImpl(
+      modelContext: testSwiftDataStorage.modelContext
+    )
+    weeklyScheduleRepository = WeeklyScheduleRepositoryImpl(
+      modelContext: testSwiftDataStorage.modelContext
+    )
+  }
+  
+  override func tearDownWithError() throws {
+    appConfigRepository = nil
+    dailyScheduleRepository = nil
+    weeklyScheduleRepository = nil
+    try super.tearDownWithError()
+  }
+  // MARK: - AppConfigRepository 테스트
+  func testAppConfigRepository() throws {
+    
+    guard let appConfigRepository = appConfigRepository else {
+      XCTFail("appConfigRepository가 nil입니다.")
+      return
+    }
+    
+    // 1. 온보딩 완료 설정 및 초기 값 검증
+    let initialWakeupTime = 1
+    let initialBedTime = 1
+    appConfigRepository.setOnboardingCompleted(
+      wakeupTime: initialWakeupTime,
+      bedTime: initialBedTime
+    )
+    
+    // 1-1. 초기 기상 시간 확인
+    let wakeupTimeFetchResultInitial = appConfigRepository.fetchWakeupTime()
+    switch wakeupTimeFetchResultInitial {
+    case .success(let data):
+      XCTAssertEqual(initialWakeupTime, data, "초기 기상 시간이 일치하지 않습니다.")
+    case .failure(let error):
+      XCTFail("fetchWakeupTime 실패: \(error)")
+    }
+    
+    // 1-2. 초기 취침 시간 확인
+    let bedTimeFetchResultInitial = appConfigRepository.fetchBedTime()
+    switch bedTimeFetchResultInitial {
+    case .success(let data):
+      XCTAssertEqual(initialBedTime, data, "초기 취침 시간이 일치하지 않습니다.")
+    case .failure(let error):
+      XCTFail("fetchBedTime 실패: \(error)")
+    }
+    
+    // 2. 온보딩 완료 상태 검증
+    let onboardingFetchResult = appConfigRepository.fetchOnboardingStatus()
+    switch onboardingFetchResult {
+    case .success(let data):
+      XCTAssertTrue(data, "온보딩 완료 상태가 true가 아닙니다.")
+    case .failure(let error):
+      XCTFail("fetchOnboardingStatus 실패: \(error)")
+    }
+    
+    // 3. 기상 시간 업데이트 후 검증
+    let mockWakeupTime = 20
+    appConfigRepository.updateWakeupTime(mockWakeupTime)
+    let wakeupTimeFetchResultUpdated = appConfigRepository.fetchWakeupTime()
+    switch wakeupTimeFetchResultUpdated {
+    case .success(let data):
+      XCTAssertEqual(mockWakeupTime, data, "업데이트된 기상 시간이 일치하지 않습니다.")
+    case .failure(let error):
+      XCTFail("fetchWakeupTime 업데이트 실패: \(error)")
+    }
+    
+    // 4. 취침 시간 업데이트 후 검증
+    let mockBedTime = 30
+    appConfigRepository.updateBedTime(mockBedTime)
+    let bedTimeFetchResultUpdated = appConfigRepository.fetchBedTime()
+    switch bedTimeFetchResultUpdated {
+    case .success(let data):
+      XCTAssertEqual(mockBedTime, data, "업데이트된 취침 시간이 일치하지 않습니다.")
+    case .failure(let error):
+      XCTFail("fetchBedTime 업데이트 실패: \(error)")
+    }
+  }
+  
+  
+  
 }

--- a/TIGTests/TIGTests.swift
+++ b/TIGTests/TIGTests.swift
@@ -1,0 +1,13 @@
+//
+//  TIGTests.swift
+//  TIGTests
+//
+//  Created by 신승재 on 2/13/25.
+//
+
+import XCTest
+@testable import TIG
+
+final class TIGTests: XCTestCase {
+
+}

--- a/TIGTests/TIGTests.swift
+++ b/TIGTests/TIGTests.swift
@@ -129,7 +129,7 @@ final class TIGTests: XCTestCase {
         XCTFail("DailySchedule이 nil 입니다.")
         return
       }
-      XCTAssertEqual(mokDailySchedule.comparable, data.comparable, "DailySchedule이 일치하지 않습니다.")
+      XCTAssertEqual(mokDailySchedule, data, "DailySchedule이 일치하지 않습니다.")
       
     case .failure(let error):
       XCTFail("fetch DailySchedule 실패: \(error)")
@@ -155,11 +155,7 @@ final class TIGTests: XCTestCase {
         XCTFail("DailySchedule이 nil 입니다.")
         return
       }
-      XCTAssertEqual(
-        mokDailySchedule.comparable,
-        data.comparable,
-        "DailySchedule이 일치하지 않습니다."
-      )
+      XCTAssertEqual(mokDailySchedule, data, "DailySchedule이 일치하지 않습니다.")
     case .failure(let error):
       XCTFail("fetch DailySchedule 실패: \(error)")
     }
@@ -181,7 +177,7 @@ final class TIGTests: XCTestCase {
       return
     }
     
-    var allWeeklySchedules: [ComparableWeeklySchedule] = []
+    var allWeeklySchedules: [WeeklySchedule] = []
     
     // 1. WeeklySchedules 초기화
     weeklyScheduleRepository.initializeWeeklySchedules()
@@ -192,7 +188,7 @@ final class TIGTests: XCTestCase {
         day: weekDay,
         timeSlots: [TimeSlot(start: 1, end: 1, isAvailable: true)]
       )
-      allWeeklySchedules.append(mokWeeklySchedule.comparable)
+      allWeeklySchedules.append(mokWeeklySchedule)
       
       weeklyScheduleRepository.updateWeeklySchedule(
         weeklySchedule: mokWeeklySchedule,
@@ -208,11 +204,7 @@ final class TIGTests: XCTestCase {
           XCTFail("\(weekDay)의 WeeklySchedule이 nil 입니다.")
           return
         }
-        XCTAssertEqual(
-          mokWeeklySchedule.comparable,
-          data.comparable,
-          "\(weekDay)의 WeeklySchedule이 일치하지 않습니다."
-        )
+        XCTAssertEqual(mokWeeklySchedule, data, "\(weekDay)의 WeeklySchedule이 일치하지 않습니다.")
       case .failure(let error):
         XCTFail("\(weekDay)의 fetch WeeklySchedule 실패: \(error)")
       }
@@ -222,8 +214,7 @@ final class TIGTests: XCTestCase {
     let allFetchResult = weeklyScheduleRepository.fetchAllWeeklySchedules()
     switch allFetchResult {
     case .success(let datas):
-      let comparableDatas = datas.map { $0.comparable }
-      XCTAssertEqual(comparableDatas, allWeeklySchedules, "All WeeklySchedule이 일치하지 않습니다.")
+      XCTAssertEqual(datas, allWeeklySchedules, "All WeeklySchedule이 일치하지 않습니다.")
     case .failure(let error):
       XCTFail("fetch All WeeklySchedules 실패: \(error)")
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 번호를 작성해 주세요 -->
<!-- ex) - close #1 -->
- close #9 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요(이미지 첨부 가능) --> 
- AppConfigRepository 테스트 코드 작성
- DailyScheduleRepository 테스트 코드 작성
- WeeklyScheduleRepository 테스트 코드 작성
- WeeklySchedule 초기화 시 오류 수정
- id 를 제외하고 비교할 수 있도록 Comparable 구조체 및 속성 추가
- 이미 저장된 객체가 있는지에 대한 예외처리 추가

## 💬 추가 설명
<!-- 추가적으로 설명할 부분이 있다면 작성해 주세요 -->
### Comparable 구조체 추가
테스트코드를 작성하면서 XCTAssertEqual로 두 객체를 비교할때, 다음과 같은 메시지가 떴습니다.
<img width="1001" alt="스크린샷 2025-02-16 오후 4 10 24" src="https://github.com/user-attachments/assets/37f39f51-cb4d-424b-9ef8-693be2f1fb1b" />

모든 구조체들에 Equatable 프로토콜을 채택하였으나 TimeSlot에서 자체로 id를 생성하기 때문에 제가 임의로 생성한 TimeSlot과 fetch 된 TimeSlot의 다른 속성값이 일치하더라도 id가 일치하지 않는 문제가 생겼습니다.

~~따라서, id를 제외한 속성만 비교할 수 이도록 각 객체마다 Equatable 프로토콜을 채택한 Comparable 구조체를 따로 작성하였습니다.~~
그냥 프로토콜 정적 메서드를 사용해서 id 값을 빼고 비교하는 방법으로 해결했습니다 ㅎ
```swift
struct TimeSlot: Equatable {
  var id: String = UUID().uuidString
  var start: Int
  var end: Int
  var isAvailable: Bool
  
  static func == (lhs: TimeSlot, rhs: TimeSlot) -> Bool {
      return lhs.start == rhs.start &&
             lhs.end == rhs.end &&
             lhs.isAvailable == rhs.isAvailable
  }
}
```


### 오류 발견 후 수정
테스트를 하던 중 다음과 같은 오류를 발견하였습니다.
WeekDay 열거형이 저번 프로젝트와 다르게 rawValue가 0부터 시작하는지 모르고 제가 initialize할때 1~7을 했더라구요,,
```swift
  func initializeWeeklySchedules() {
    print("Impl:", #function)

    (1...7).forEach {
      let model = WeeklyScheduleDTO(day: $0, timeSlots: [])
      modelContext.insert(model)
    }
  }
```
그래서 이 부분 고쳤습니다...

### 그외
이미있는 객체에 대한 예외처리 부분 봐주시면 감사하겠습니다.