### PR TITLE
[Feature] 가용시간 뷰 디테일 로직 적용

### DIFF
--- a/TIG/Sources/Feature/Home/AvailableTime/AvailableTimeView.swift
+++ b/TIG/Sources/Feature/Home/AvailableTime/AvailableTimeView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct AvailableTimeView: View {
   let homeViewModel: HomeViewModel
   private var isToday: Bool {
-    homeViewModel.state.currentDate.isToday
+    homeViewModel.state.selectedDate.isToday
   }
   
   var body: some View {
@@ -59,7 +59,7 @@ private struct HeaderView: View {
   }
 }
 
-// TODO: 수정 필요
+// TODO: 코드 리팩토링 필요
 private struct TimerView: View {
   let homeViewModel: HomeViewModel
   
@@ -156,6 +156,8 @@ private struct TimerView: View {
         let nextTimeSlot = homeViewModel.state.groupedTimeSlots[index + 1]
         return nextTimeSlot.duration.time(format: .duration_kr)
       }
+    
+    // 현재 가용시간인 경우
     } else {
       let remainSeconds = homeViewModel.state.currentTimeSlot.end - homeViewModel.state.currentTimeInSeconds
       return remainSeconds.time(format: .duration_kr)
@@ -163,8 +165,11 @@ private struct TimerView: View {
   }
   
   private func getSubTitle() -> String {
+    // 현재 비가용시간인 경우
     if !isAvailable {
+      // 현재 마지막 타임슬롯인 경우
       if isLastTimeSlot { return "" }
+      // 아닌 경우
       else {
         let nowSeconds = homeViewModel.state.currentTimeInSeconds
         guard let index = homeViewModel.state.groupedTimeSlots.firstIndex(where: {
@@ -175,6 +180,8 @@ private struct TimerView: View {
         let end = nextTimeSlot.end.time(format: .ampm_kr)
         return "\(start) - \(end)"
       }
+      
+    // 현재 가용시간인 경우
     } else {
       let currentTimeSlot = homeViewModel.state.currentTimeSlot
       return "/ \(currentTimeSlot.duration.time(format: .duration_kr))"
@@ -204,7 +211,7 @@ private struct FooterView: View {
   }
   
   private var isToday: Bool {
-    homeViewModel.state.currentDate.isToday
+    homeViewModel.state.selectedDate.isToday
   }
   
   var body: some View {
@@ -226,7 +233,7 @@ private struct FooterView: View {
       
       Spacer()
       
-      if Date().formattedDate <= homeViewModel.state.currentDate {
+      if Date().formattedDate <= homeViewModel.state.selectedDate {
         Button {
           
         } label: {

--- a/TIG/Sources/Feature/Home/AvailableTime/AvailableTimeView.swift
+++ b/TIG/Sources/Feature/Home/AvailableTime/AvailableTimeView.swift
@@ -12,7 +12,7 @@ struct AvailableTimeView: View {
   
   var body: some View {
     VStack(spacing: 0) {
-      CurrentTimeView(homeViewModel: homeViewModel)
+      HeaderView(homeViewModel: homeViewModel)
         .padding(.top, 40)
       TimerView(homeViewModel: homeViewModel)
         .padding(.top, 34)
@@ -24,7 +24,7 @@ struct AvailableTimeView: View {
   }
 }
 
-private struct CurrentTimeView: View {
+private struct HeaderView: View {
   private var startTime: String
   private var endTime: String
   private var isAvailable: Bool
@@ -57,14 +57,12 @@ private struct CurrentTimeView: View {
 private struct TimerView: View {
   let homeViewModel: HomeViewModel
   
-  private var remainTime: String {
-    let remainSeconds = homeViewModel.state.currentTimeSlot.end - homeViewModel.state.currentTimeInSeconds
-    return remainSeconds.time(format: .duration_kr)
+  private var mainTitle: String {
+    getMainTitle()
   }
   
-  private var totalTime: String {
-    let totalSeconds = homeViewModel.state.currentTimeSlot.end - homeViewModel.state.currentTimeSlot.start
-    return totalSeconds.time(format: .duration_kr)
+  private var subTitle: String {
+    getSubTitle()
   }
   
   private var isAvailable: Bool {
@@ -78,6 +76,11 @@ private struct TimerView: View {
     let start = homeViewModel.state.currentTimeSlot.start
     let end = homeViewModel.state.currentTimeSlot.end
     return CGFloat(now - start) / CGFloat(end - start)
+  }
+  
+  private var isLastTimeSlot: Bool {
+    let currentTimeSlot = homeViewModel.state.currentTimeSlot
+    return currentTimeSlot.end == Time.hour * 24
   }
   
   var body: some View {
@@ -117,11 +120,11 @@ private struct TimerView: View {
         .background(isAvailable ? .blueMain : .gray02)
         .clipShape(Capsule())
       
-      Text(remainTime)
+      Text(mainTitle)
         .font(.pretendard(size: 36, weight: .semiBold))
         .foregroundStyle(isAvailable ? .blueMain : .gray02)
       
-      Text("/ \(totalTime)")
+      Text("\(subTitle)")
         .font(.pretendard(size: 16, weight: .medium))
         .foregroundStyle(isAvailable ? .gray06 : .gray02)
         // 중간 텍스트를 중앙에 배치하기 위해 spacing을 동일하게 주고 offset으로 위치 이동
@@ -131,6 +134,45 @@ private struct TimerView: View {
     // 상단, 하단에 위치한 텍스트의 높이가 각각 26, 19로 다름
     // 상단 텍스트가 7만큼 더 높이가 크기 때문에 그 절반만큼 뷰를 위로 옮김
     .offset(y: -3.5)
+  }
+  
+  private func getMainTitle() -> String {
+    // 현재 비가용시간인 경우
+    if !isAvailable {
+      // 현재 마지막 타임슬롯인 경우
+      if isLastTimeSlot { return "0시간 0분" }
+      // 아닌 경우
+      else {
+        let nowSeconds = homeViewModel.state.currentTimeInSeconds
+        guard let index = homeViewModel.state.groupedTimeSlots.firstIndex(where: {
+          $0.start <= nowSeconds && nowSeconds < $0.end
+        }) else { return "" }
+        let nextTimeSlot = homeViewModel.state.groupedTimeSlots[index + 1]
+        return nextTimeSlot.duration.time(format: .duration_kr)
+      }
+    } else {
+      let remainSeconds = homeViewModel.state.currentTimeSlot.end - homeViewModel.state.currentTimeInSeconds
+      return remainSeconds.time(format: .duration_kr)
+    }
+  }
+  
+  private func getSubTitle() -> String {
+    if !isAvailable {
+      if isLastTimeSlot { return "" }
+      else {
+        let nowSeconds = homeViewModel.state.currentTimeInSeconds
+        guard let index = homeViewModel.state.groupedTimeSlots.firstIndex(where: {
+          $0.start <= nowSeconds && nowSeconds < $0.end
+        }) else { return "" }
+        let nextTimeSlot = homeViewModel.state.groupedTimeSlots[index + 1]
+        let start = nextTimeSlot.start.time(format: .ampm_kr)
+        let end = nextTimeSlot.end.time(format: .ampm_kr)
+        return "\(start) - \(end)"
+      }
+    } else {
+      let currentTimeSlot = homeViewModel.state.currentTimeSlot
+      return "/ \(currentTimeSlot.duration.time(format: .duration_kr))"
+    }
   }
 }
 

--- a/TIG/Sources/Feature/Home/AvailableTime/AvailableTimeView.swift
+++ b/TIG/Sources/Feature/Home/AvailableTime/AvailableTimeView.swift
@@ -226,17 +226,19 @@ private struct FooterView: View {
       
       Spacer()
       
-      Button {
-        
-      } label: {
-        Text("시간 수정")
-          .foregroundStyle(.blueMain)
-          .font(.pretendard(size: 14, weight: .medium))
+      if Date().formattedDate <= homeViewModel.state.currentDate {
+        Button {
+          
+        } label: {
+          Text("시간 수정")
+            .foregroundStyle(.blueMain)
+            .font(.pretendard(size: 14, weight: .medium))
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 18)
+        .background(.blueButton)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
       }
-      .padding(.vertical, 10)
-      .padding(.horizontal, 18)
-      .background(.blueButton)
-      .clipShape(RoundedRectangle(cornerRadius: 8))
     }
     .padding(.horizontal, 20)
     .padding(.vertical, 22)

--- a/TIG/Sources/Feature/Home/AvailableTime/AvailableTimeView.swift
+++ b/TIG/Sources/Feature/Home/AvailableTime/AvailableTimeView.swift
@@ -9,13 +9,18 @@ import SwiftUI
 
 struct AvailableTimeView: View {
   let homeViewModel: HomeViewModel
+  private var isToday: Bool {
+    homeViewModel.state.currentDate.isToday
+  }
   
   var body: some View {
     VStack(spacing: 0) {
-      HeaderView(homeViewModel: homeViewModel)
-        .padding(.top, 40)
-      TimerView(homeViewModel: homeViewModel)
-        .padding(.top, 34)
+      if isToday {
+        HeaderView(homeViewModel: homeViewModel)
+          .padding(.top, 40)
+        TimerView(homeViewModel: homeViewModel)
+          .padding(.top, 34)
+      }
       FooterView(homeViewModel: homeViewModel)
         .padding(.top, 36)
     }
@@ -54,6 +59,7 @@ private struct HeaderView: View {
   }
 }
 
+// TODO: 수정 필요
 private struct TimerView: View {
   let homeViewModel: HomeViewModel
   
@@ -197,13 +203,24 @@ private struct FooterView: View {
       .time(format: .duration_kr)
   }
   
+  private var isToday: Bool {
+    homeViewModel.state.currentDate.isToday
+  }
+  
   var body: some View {
     HStack {
       VStack(alignment: .leading, spacing: 5) {
         Text("하루 가용시간")
           .font(.pretendard(size: 12, weight: .regular))
-        Text("\(remainTime) / \(totalTime)")
-          .font(.pretendard(size: 16, weight: .semiBold))
+        
+        HStack(spacing: 0) {
+          if isToday {
+            Text("\(remainTime)")
+            Text(" / ")
+          }
+          Text("\(totalTime)")
+        }
+        .font(.pretendard(size: 16, weight: .semiBold))
       }
       .foregroundStyle(.gray04)
       

--- a/TIG/Sources/Feature/Home/HomeView.swift
+++ b/TIG/Sources/Feature/Home/HomeView.swift
@@ -56,7 +56,7 @@ struct HomeView: View {
   
   @ViewBuilder
   private var calendarButton: some View {
-    let currentDate = homeViewModel.state.currentDate
+    let currentDate = homeViewModel.state.selectedDate
     Button {
       isPresented = true
     } label: {
@@ -107,7 +107,7 @@ private struct CalendarPickerView: View {
       DatePicker(
         "",
         selection: .init(
-          get: { homeViewModel.state.currentDate },
+          get: { homeViewModel.state.selectedDate },
           set: { homeViewModel.send(.selectDate($0)) }
         ),
         displayedComponents: .date
@@ -137,7 +137,7 @@ private struct CalendarPickerView: View {
     .frame(maxHeight: .infinity, alignment: .top)
     .padding(.vertical, 24)
     .padding(.horizontal, 16)
-    .onChange(of: homeViewModel.state.currentDate) { _, _ in
+    .onChange(of: homeViewModel.state.selectedDate) { _, _ in
       isPresented = false
     }
   }

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -115,7 +115,7 @@ private extension HomeViewModel {
   /// - Parameter date: 날짜
   func initializeTimeSlot(date: Date) {
     
-    let result = getDailySchedule(date: date)
+    let result = fetchDailySchedule(date: date)
     switch result {
     case .success(let dailySchedule):
       state.timeSlots = dailySchedule.timeSlots
@@ -126,82 +126,64 @@ private extension HomeViewModel {
   }
   
   /// DB에서 해당 날짜에 맞는 DailySchedule을 가져옵니다.
+  /// 없는 경우, WeeklySchedule 또는 수면 시간 기준으로 생성합니다.
   /// - Parameter date: 불러올 날짜
   /// - Returns: DailySchedule
-  func getDailySchedule(date: Date) -> Result<DailySchedule, Error> {
-    let result = dailyScheduleRepository.fetchDailySchedule(date: date)
-    
-    switch result {
+  func fetchDailySchedule(date: Date) -> Result<DailySchedule, Error> {
+    // 1. DailySchedule이 있으면 바로 반환
+    switch dailyScheduleRepository.fetchDailySchedule(date: date) {
     case .success(let dailySchedule):
-      if let dailySchedule = dailySchedule {
+      if let dailySchedule {
         return .success(dailySchedule)
-      } else {
-        return getDailyScheduleFromWeeklySchedule(date: date)
       }
       
     case .failure(let error):
       return .failure(error)
     }
-  }
-  
-  /// WeeklySchedule로부터 DailySchedule을 가져옵니다.
-  /// - Parameter date: 불러올 날짜
-  /// - Returns: DailySchedule
-  func getDailyScheduleFromWeeklySchedule(date: Date) -> Result<DailySchedule, Error> {
-    let result = weeklyScheduleRepository.fetchWeeklySchedule(weekDay: WeekDay(rawValue: date.weekday - 1)!)
     
-    switch result {
-    case .success(let weekdaySchedule):
-      if let weekdaySchedule = weekdaySchedule {
+    // 2. 설정된 WeeklySchedule로 DailySchedule 불러오기
+    let weekDay = WeekDay(rawValue: date.weekday - 1)!
+    switch weeklyScheduleRepository.fetchWeeklySchedule(weekDay: weekDay) {
+    case .success(let weeklySchedule):
+      if let weeklySchedule {
         let dailySchedule = DailySchedule(
           date: date.formattedDate,
-          timeSlots: weekdaySchedule.timeSlots
+          timeSlots: weeklySchedule.timeSlots
         )
         
-        // getDailySchedule()을 통해 선택된 날짜에 대한 DailySchedule이 없는 경우 이 메서드를 실행하게 됨
-        // 이때 DailySchedule을 불러오는 날짜가 오늘 날짜인 경우 DailySchedule 저장
+        // 오늘 날짜의 dailySchedule인 경우 저장
         if date.isToday {
           dailyScheduleRepository.createDailySchedule(dailySchedule)
         }
         
         return .success(dailySchedule)
-      } else {
-        return getDailyScheduleFromSleepTime(date: date)
       }
+      
     case .failure(let error):
       return .failure(error)
     }
-  }
-  
-  /// 수면 시간에 맞춘 DailySchedule을 불러옵니다.
-  /// - Returns: DailySchedule
-  func getDailyScheduleFromSleepTime(date: Date) -> Result<DailySchedule, Error> {
-    let wakeupTime = appConfigRepository.fetchWakeupTime()
-    let bedTime = appConfigRepository.fetchBedTime()
     
+    // 3. 설정된 수면 시간 기준으로 DailySchedule 불러오기
     do {
-      let wakeup = try wakeupTime.get()
-      let bed = try bedTime.get()
+      let wakeup = try appConfigRepository.fetchWakeupTime().get()
+      let bed = try appConfigRepository.fetchBedTime().get()
       
-      var timeSlots: [TimeSlot] = []
-      
-      for time in stride(from: 0, to: Time.hour * 24, by: Time.interval) {
-        timeSlots.append(TimeSlot(
-          start: time,
-          end: time + Time.interval,
-          isAvailable: wakeup <= time && time < bed ? true : false
-        ))
+      let timeSlots = stride(from: 0, to: Time.hour * 24, by: Time.interval).map {
+        TimeSlot(
+          start: $0,
+          end: $0 + Time.interval,
+          isAvailable: wakeup <= $0 && $0 < bed
+        )
       }
       
-      // getDailySchedule()을 통해 선택된 날짜에 대한 DailySchedule이 없는 경우와
-      // 주간 반복 데이터가 없는 경우 이 메서드를 실행하게 됨
-      // 이때 DailySchedule을 불러오는 날짜가 오늘 날짜인 경우 DailySchedule 저장
+      // 오늘 날짜의 dailySchedule인 경우 저장
       let dailySchedule = DailySchedule(date: date.formattedDate, timeSlots: timeSlots)
       if date.isToday {
         dailyScheduleRepository.createDailySchedule(dailySchedule)
       }
       
       return .success(dailySchedule)
+      
     } catch {
       return .failure(error)
     }

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -24,7 +24,7 @@ final class HomeViewModel {
     // 타임 슬롯 상태
     var timeSlots: [TimeSlot] = []
     var groupedTimeSlots: [GroupedTimeSlot] = []
-    var currentTimeSlot: GroupedTimeSlot = .init(start: 0, end: 0, isAvailable: false, count: 0)
+    var currentTimeSlot: GroupedTimeSlot = .init(start: 0, end: 0, isAvailable: false, duration: 0, count: 0)
   }
   
   enum Action {
@@ -155,6 +155,6 @@ private extension HomeViewModel {
     // ?? 임의의 값
     return state.groupedTimeSlots.first(where: {
       $0.start <= totalSeconds && $0.end > totalSeconds
-    }) ?? state.groupedTimeSlots.first ?? GroupedTimeSlot(start: 0, end: 0, isAvailable: false, count: 0)
+    })!
   }
 }

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -41,6 +41,7 @@ final class HomeViewModel {
   
   private(set) var state: State = .init()
   
+  // TODO: 외부 주입 필요
   private let dailyScheduleRepository: DailyScheduleRepository = StubDailyScheduleRepository()
   private let weeklyScheduleRepository: WeeklyScheduleRepository = StubWeeklyScheduleRepository()
   private let appConfigRepository: AppConfigRepository = StubAppConfigRepository()
@@ -48,6 +49,7 @@ final class HomeViewModel {
   func send(_ action: Action) {
     switch action {
     case .onAppear:
+      // TODO: 첫 진입 시에만 호출되도록 수정 필요할 듯
       handleTimer()
       initializeTimeSlot(date: state.currentDate)
     case .onDisappear:

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -13,11 +13,10 @@ final class HomeViewModel {
   struct State {
     var timerCancellable: Cancellable?
     
-    // TODO: CurrentTime 이름으로 초단위가 아닌 Date 타입으로 저장해보기
+    // TODO: CurrentTime 이름으로 초단위가 아닌 Date 타입으로 저장하는 게 더 나을지 생각 필요
     var currentTimeInSeconds: Int = Date().totalSeconds
     
-    // TODO: SelectedDate로 네이밍 수정
-    var currentDate: Date = Date().formattedDate
+    var selectedDate: Date = Date().formattedDate
     
     // 탭바 상태
     var selectedTab: HomeTab = .available
@@ -25,7 +24,7 @@ final class HomeViewModel {
     // 타임 슬롯 상태
     var timeSlots: [TimeSlot] = []
     var groupedTimeSlots: [GroupedTimeSlot] = []
-    var currentTimeSlot: GroupedTimeSlot = .init(start: 0, end: 0, isAvailable: false, duration: 0, count: 0)
+    var currentTimeSlot: GroupedTimeSlot = .mock
   }
   
   enum Action {
@@ -41,22 +40,31 @@ final class HomeViewModel {
   
   private(set) var state: State = .init()
   
-  // TODO: 외부 주입 필요
-  private let dailyScheduleRepository: DailyScheduleRepository = StubDailyScheduleRepository()
-  private let weeklyScheduleRepository: WeeklyScheduleRepository = StubWeeklyScheduleRepository()
-  private let appConfigRepository: AppConfigRepository = StubAppConfigRepository()
+  private let dailyScheduleRepository: DailyScheduleRepository
+  private let weeklyScheduleRepository: WeeklyScheduleRepository
+  private let appConfigRepository: AppConfigRepository
+  
+  init(
+    dailyScheduleRepository: DailyScheduleRepository = StubDailyScheduleRepository(),
+    weeklyScheduleRepository: WeeklyScheduleRepository = StubWeeklyScheduleRepository(),
+    appconfigRepository: AppConfigRepository = StubAppConfigRepository()
+  ) {
+    self.dailyScheduleRepository = dailyScheduleRepository
+    self.weeklyScheduleRepository = weeklyScheduleRepository
+    self.appConfigRepository = appconfigRepository
+  }
   
   func send(_ action: Action) {
     switch action {
     case .onAppear:
       // TODO: 첫 진입 시에만 호출되도록 수정 필요할 듯
       handleTimer()
-      initializeTimeSlot(date: state.currentDate)
+      initializeTimeSlot(date: state.selectedDate)
     case .onDisappear:
       stopTimer()
       
     case .selectDate(let date):
-      state.currentDate = date.formattedDate
+      state.selectedDate = date.formattedDate
       handleTimer()
       initializeTimeSlot(date: date)
       
@@ -71,7 +79,7 @@ private extension HomeViewModel {
   /// 타이머를 조작합니다.
   /// 현재 선택된 날짜가 오늘 날짜인 경우에만 타이머를 실행하고 그 외 날짜는 타이머 동작을 멈춥니다.
   func handleTimer() {
-    if state.currentDate.isToday { startTimer() }
+    if state.selectedDate.isToday { startTimer() }
     else { stopTimer() }
   }
   
@@ -93,11 +101,11 @@ private extension HomeViewModel {
     state.currentTimeInSeconds = date.totalSeconds
     
     // 다음 날짜로 넘어가는 시점인 경우 TimeSlot 업데이트
-    if state.currentDate != date.formattedDate {
+    if state.selectedDate != date.formattedDate {
       initializeTimeSlot(date: date)
       
       // 현재 선택된 날짜 업데이트
-      state.currentDate = date.formattedDate
+      state.selectedDate = date.formattedDate
     } else {
       // 현재 위치한 TimeSlot만 업데이트
       state.currentTimeSlot = getCurrentGroupedTimeSlot()

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -14,8 +14,6 @@ final class HomeViewModel {
     var timerCancellable: Cancellable?
     var currentTimeInSeconds: Int = Date().totalSeconds
     
-    // 주간 캘린더 상태
-    var weekSlider: [[Date.WeekDay]] = []
     var currentDate: Date = Date().formattedDate
     
     // 탭바 상태
@@ -33,7 +31,6 @@ final class HomeViewModel {
     
     // 주간 캘린더 액션
     case selectDate(Date)
-    case moveWeekPeriod(index: Int)
     
     // 탭바 액션
     case changeTab(HomeTab)
@@ -48,22 +45,13 @@ final class HomeViewModel {
   func send(_ action: Action) {
     switch action {
     case .onAppear:
-      if state.weekSlider.isEmpty {
-        state.weekSlider = generateWeekSlider()
-      }
       handleTimer()
       initializeTimeSlot(date: state.currentDate)
-      
+      print(try? dailyScheduleRepository.fetchAllDailySchedules().get())
     case .onDisappear:
       stopTimer()
       
-    case .moveWeekPeriod(let index):
-      if state.weekSlider.indices.contains(index) {
-        paginateWeek(currentIndex: index)
-      }
-      
     case .selectDate(let date):
-      state.weekSlider = generateWeekSlider(anchor: date)
       state.currentDate = date.formattedDate
       handleTimer()
       initializeTimeSlot(date: date)
@@ -119,45 +107,6 @@ private extension HomeViewModel {
   }
 }
 
-// MARK: - Weekly Calendar Function
-private extension HomeViewModel {
-  /// 기준 날짜가 속한 주를 포함한 이전, 다음 주 데이터 묶음을 생성
-  /// - Parameter date: 기준이 되는 날짜
-  /// - Returns: 기준 날짜가 속한 주를 포함한 이전, 다음 주 데이터 묶음
-  func generateWeekSlider(anchor date: Date = .now) -> [[Date.WeekDay]] {
-    var newWeeks = [[Date.WeekDay]]()
-    let anchorWeek = date.weekOfDate
-    
-    if let firstDate = anchorWeek.first?.date {
-      newWeeks.append(firstDate.createPreviousWeek())
-    }
-    
-    newWeeks.append(anchorWeek)
-    
-    if let lastDate = anchorWeek.last?.date {
-      newWeeks.append(lastDate.createNextWeek())
-    }
-    
-    return newWeeks
-  }
-  
-  /// 현재 주간 캘린더 위치가 weekSlider의 첫번째 또는 마지막인 경우 새로 생성
-  /// - Parameter currentIndex: 현재 위치한 주간 캘린더 인덱스
-  func paginateWeek(currentIndex: Int) {
-    if let firstDate = state.weekSlider[currentIndex].first?.date,
-       currentIndex == 0 {
-      state.weekSlider.insert(firstDate.createPreviousWeek(), at: 0)
-      state.weekSlider.removeLast()
-    }
-    
-    if let lastDate = state.weekSlider[currentIndex].last?.date,
-       currentIndex == (state.weekSlider.count - 1) {
-      state.weekSlider.append(lastDate.createNextWeek())
-      state.weekSlider.removeFirst()
-    }
-  }
-}
-
 // MARK: - TimeSlot Function
 private extension HomeViewModel {
   /// 특정 날짜에 맞는 TimeSlots로 상태를 초기화 합니다.
@@ -203,12 +152,20 @@ private extension HomeViewModel {
     switch result {
     case .success(let weekdaySchedule):
       if let weekdaySchedule = weekdaySchedule {
-        return .success(DailySchedule(
-          date: date,
+        let dailySchedule = DailySchedule(
+          date: date.formattedDate,
           timeSlots: weekdaySchedule.timeSlots
-        ))
+        )
+        
+        // getDailySchedule()을 통해 선택된 날짜에 대한 DailySchedule이 없는 경우 이 메서드를 실행하게 됨
+        // 이때 DailySchedule을 불러오는 날짜가 오늘 날짜인 경우 DailySchedule 저장
+        if date.isToday {
+          dailyScheduleRepository.createDailySchedule(dailySchedule)
+        }
+        
+        return .success(dailySchedule)
       } else {
-        return getDailyScheduleFromSleepTime()
+        return getDailyScheduleFromSleepTime(date: date)
       }
     case .failure(let error):
       return .failure(error)
@@ -217,7 +174,7 @@ private extension HomeViewModel {
   
   /// 수면 시간에 맞춘 DailySchedule을 불러옵니다.
   /// - Returns: DailySchedule
-  func getDailyScheduleFromSleepTime() -> Result<DailySchedule, Error> {
+  func getDailyScheduleFromSleepTime(date: Date) -> Result<DailySchedule, Error> {
     let wakeupTime = appConfigRepository.fetchWakeupTime()
     let bedTime = appConfigRepository.fetchBedTime()
     
@@ -235,7 +192,15 @@ private extension HomeViewModel {
         ))
       }
       
-      return .success(DailySchedule(date: Date().formattedDate, timeSlots: timeSlots))
+      // getDailySchedule()을 통해 선택된 날짜에 대한 DailySchedule이 없는 경우와
+      // 주간 반복 데이터가 없는 경우 이 메서드를 실행하게 됨
+      // 이때 DailySchedule을 불러오는 날짜가 오늘 날짜인 경우 DailySchedule 저장
+      let dailySchedule = DailySchedule(date: date.formattedDate, timeSlots: timeSlots)
+      if date.isToday {
+        dailyScheduleRepository.createDailySchedule(dailySchedule)
+      }
+      
+      return .success(dailySchedule)
     } catch {
       return .failure(error)
     }
@@ -244,6 +209,8 @@ private extension HomeViewModel {
   /// 현재 시간대에 위치한 그룹화된 TimeSlot을 가져옵니다
   /// - Returns: 현재 시간대에 위치한 GroupedTimeSlot
   func getCurrentGroupedTimeSlot() -> GroupedTimeSlot {
+    // TODO: 오늘 날짜가 아닌 경우에 대한 생각 필요
+    // currentGroupedTimeSlot 대신 index로 대체 후 오늘 날짜가 아닌 경우 -1로 저장 등등
     let now = Date()
     let totalSeconds = now.totalSeconds
     

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -62,6 +62,7 @@ final class HomeViewModel {
       state.weekSlider = generateWeekSlider(anchor: date)
       state.currentDate = date.formattedDate
       handleTimer()
+      initializeTimeSlot(date: date)
       
     case .changeTab(let tab):
       state.selectedTab = tab
@@ -83,14 +84,34 @@ private extension HomeViewModel {
       .publish(every: 1, on: .main, in: .common)
       .autoconnect()
       .sink(receiveValue: { [weak self] date in
-        self?.state.currentTimeInSeconds = date.totalSeconds
-        
-        // TODO: 현재 위치한 타임 슬롯 가져오는 로직 구현
+        self?.processTimerTask(date: date)
       })
   }
   
   func stopTimer() {
     state.timerCancellable?.cancel()
+  }
+  
+  // TODO: 수정 필요
+  func processTimerTask(date: Date) {
+    // 현재 선택된 날짜가 현재 날짜와 다른 경우 TimeSlot 업데이트
+    if state.currentDate != date.formattedDate {
+      initializeTimeSlot(date: date)
+    }
+    
+    // 현재 선택된 날짜 업데이트
+    state.currentDate = date.formattedDate
+    
+    // 현재 시간(초) 업데이트
+    let currentSeconds = date.totalSeconds
+    state.currentTimeInSeconds = currentSeconds
+    
+    // 현재 위치한 타임 슬롯 업데이트
+    guard let currentTimeSlot = state.groupedTimeSlots.first(where: {
+      $0.start <= currentSeconds && currentSeconds < $0.end
+    }) else { return }
+    
+    state.currentTimeSlot = currentTimeSlot
   }
 }
 
@@ -138,7 +159,13 @@ private extension HomeViewModel {
   /// State 내에 정의된 TimeSlot 변수들을 초기화 합니다
   func initializeTimeSlot(date: Date) {
     // TODO: 현재 선택된 날짜에 맞춰 TimeSlot 가져오는 로직 필요
-    state.timeSlots = TimeSlot.mock
+    // 1. 현재 선택된 날짜의 DailySchedule 가져오기
+    // 2. 만약 없다면 WeeklySchedule을 통해 생성
+    // 3. WeeklySchedule 또한 없다면 기상, 수면시간에 맞춰 생성
+    // 현재는 Test
+    let now = Date().formattedDate
+    let mock = now == date.formattedDate ? TimeSlot.mock : TimeSlot.mock.map { TimeSlot(start: $0.start, end: $0.end, isAvailable: Bool.random()) }
+    state.timeSlots = mock
     state.groupedTimeSlots = state.timeSlots.groupedTimeSlots
     state.currentTimeSlot = getCurrentGroupedTimeSlot()
   }
@@ -149,10 +176,6 @@ private extension HomeViewModel {
     let now = Date()
     let totalSeconds = now.totalSeconds
     
-    // TODO: 앱 플로우가 어떻게 이루어지는지 확인 후 수정 필요
-    // 오늘 날짜에 대한 타임 슬롯인 경우 현재 위치한 타임 슬롯 가져오기
-    // ?? 미래 날짜의 타임 슬롯인 경우 첫번째 타임 슬롯 가져오기
-    // ?? 임의의 값
     return state.groupedTimeSlots.first(where: {
       $0.start <= totalSeconds && $0.end > totalSeconds
     })!

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -24,7 +24,9 @@ final class HomeViewModel {
     // 타임 슬롯 상태
     var timeSlots: [TimeSlot] = []
     var groupedTimeSlots: [GroupedTimeSlot] = []
-    var currentTimeSlot: GroupedTimeSlot = .mock
+    var currentTimeSlot: GroupedTimeSlot {
+      self.groupedTimeSlots.currentTimeSlot
+    }
   }
   
   enum Action {
@@ -58,15 +60,15 @@ final class HomeViewModel {
     switch action {
     case .onAppear:
       // TODO: 첫 진입 시에만 호출되도록 수정 필요할 듯
-      handleTimer()
       initializeTimeSlot(date: state.selectedDate)
+      handleTimer()
     case .onDisappear:
       stopTimer()
       
     case .selectDate(let date):
       state.selectedDate = date.formattedDate
-      handleTimer()
       initializeTimeSlot(date: date)
+      handleTimer()
       
     case .changeTab(let tab):
       state.selectedTab = tab
@@ -87,29 +89,23 @@ private extension HomeViewModel {
     state.timerCancellable = Timer
       .publish(every: 1, on: .main, in: .common)
       .autoconnect()
-      .sink(receiveValue: { [weak self] date in
-        self?.processTimerTask(date: date)
+      .sink(receiveValue: { [weak self] now in
+        // 현재 시간(초) 업데이트
+        self?.state.currentTimeInSeconds = now.totalSeconds
+        
+        // 현재 선택된 날짜가 타이머 날짜(현재 날짜)와 일치하지 않는 경우 -> 다음날로 넘어가는 시점
+        if self?.state.selectedDate != now.formattedDate {
+          // 타임슬롯 초기화(업데이트)
+          self?.initializeTimeSlot(date: now)
+          
+          // 현재 선택된 날짜 업데이트
+          self?.state.selectedDate = now.formattedDate
+        }
       })
   }
   
   func stopTimer() {
     state.timerCancellable?.cancel()
-  }
-  
-  func processTimerTask(date: Date) {
-    // 현재 시간(초) 업데이트
-    state.currentTimeInSeconds = date.totalSeconds
-    
-    // 다음 날짜로 넘어가는 시점인 경우 TimeSlot 업데이트
-    if state.selectedDate != date.formattedDate {
-      initializeTimeSlot(date: date)
-      
-      // 현재 선택된 날짜 업데이트
-      state.selectedDate = date.formattedDate
-    } else {
-      // 현재 위치한 TimeSlot만 업데이트
-      state.currentTimeSlot = getCurrentGroupedTimeSlot()
-    }
   }
 }
 
@@ -124,7 +120,6 @@ private extension HomeViewModel {
     case .success(let dailySchedule):
       state.timeSlots = dailySchedule.timeSlots
       state.groupedTimeSlots = state.timeSlots.groupedTimeSlots
-      state.currentTimeSlot = getCurrentGroupedTimeSlot()
     case .failure:
       break
     }
@@ -194,7 +189,7 @@ private extension HomeViewModel {
         timeSlots.append(TimeSlot(
           start: time,
           end: time + Time.interval,
-          isAvailable: wakeup <= time && time < bed - Time.interval ? true : false
+          isAvailable: wakeup <= time && time < bed ? true : false
         ))
       }
       
@@ -210,18 +205,5 @@ private extension HomeViewModel {
     } catch {
       return .failure(error)
     }
-  }
-  
-  /// 현재 시간대에 위치한 그룹화된 TimeSlot을 가져옵니다
-  /// - Returns: 현재 시간대에 위치한 GroupedTimeSlot
-  func getCurrentGroupedTimeSlot() -> GroupedTimeSlot {
-    // TODO: 오늘 날짜가 아닌 경우에 대한 생각 필요
-    // currentGroupedTimeSlot 대신 index로 대체 후 오늘 날짜가 아닌 경우 -1로 저장 등등
-    let now = Date()
-    let totalSeconds = now.totalSeconds
-    
-    return state.groupedTimeSlots.first(where: {
-      $0.start <= totalSeconds && $0.end > totalSeconds
-    })!
   }
 }

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -41,6 +41,10 @@ final class HomeViewModel {
   
   private(set) var state: State = .init()
   
+  private let dailyScheduleRepository: DailyScheduleRepository = StubDailyScheduleRepository()
+  private let weeklyScheduleRepository: WeeklyScheduleRepository = StubWeeklyScheduleRepository()
+  private let appConfigRepository: AppConfigRepository = StubAppConfigRepository()
+  
   func send(_ action: Action) {
     switch action {
     case .onAppear:
@@ -156,18 +160,85 @@ private extension HomeViewModel {
 
 // MARK: - TimeSlot Function
 private extension HomeViewModel {
-  /// State 내에 정의된 TimeSlot 변수들을 초기화 합니다
+  /// 특정 날짜에 맞는 TimeSlots로 상태를 초기화 합니다.
+  /// - Parameter date: 날짜
   func initializeTimeSlot(date: Date) {
-    // TODO: 현재 선택된 날짜에 맞춰 TimeSlot 가져오는 로직 필요
-    // 1. 현재 선택된 날짜의 DailySchedule 가져오기
-    // 2. 만약 없다면 WeeklySchedule을 통해 생성
-    // 3. WeeklySchedule 또한 없다면 기상, 수면시간에 맞춰 생성
-    // 현재는 Test
-    let now = Date().formattedDate
-    let mock = now == date.formattedDate ? TimeSlot.mock : TimeSlot.mock.map { TimeSlot(start: $0.start, end: $0.end, isAvailable: Bool.random()) }
-    state.timeSlots = mock
-    state.groupedTimeSlots = state.timeSlots.groupedTimeSlots
-    state.currentTimeSlot = getCurrentGroupedTimeSlot()
+    
+    let result = getDailySchedule(date: date)
+    switch result {
+    case .success(let dailySchedule):
+      state.timeSlots = dailySchedule.timeSlots
+      state.groupedTimeSlots = state.timeSlots.groupedTimeSlots
+      state.currentTimeSlot = getCurrentGroupedTimeSlot()
+    case .failure:
+      break
+    }
+  }
+  
+  /// DB에서 해당 날짜에 맞는 DailySchedule을 가져옵니다.
+  /// - Parameter date: 불러올 날짜
+  /// - Returns: DailySchedule
+  func getDailySchedule(date: Date) -> Result<DailySchedule, Error> {
+    let result = dailyScheduleRepository.fetchDailySchedule(date: date)
+    
+    switch result {
+    case .success(let dailySchedule):
+      if let dailySchedule = dailySchedule {
+        return .success(dailySchedule)
+      } else {
+        return getDailyScheduleFromWeeklySchedule(date: date)
+      }
+      
+    case .failure(let error):
+      return .failure(error)
+    }
+  }
+  
+  /// WeeklySchedule로부터 DailySchedule을 가져옵니다.
+  /// - Parameter date: 불러올 날짜
+  /// - Returns: DailySchedule
+  func getDailyScheduleFromWeeklySchedule(date: Date) -> Result<DailySchedule, Error> {
+    let result = weeklyScheduleRepository.fetchWeeklySchedule(weekDay: WeekDay(rawValue: date.weekday - 1)!)
+    
+    switch result {
+    case .success(let weekdaySchedule):
+      if let weekdaySchedule = weekdaySchedule {
+        return .success(DailySchedule(
+          date: date,
+          timeSlots: weekdaySchedule.timeSlots
+        ))
+      } else {
+        return getDailyScheduleFromSleepTime()
+      }
+    case .failure(let error):
+      return .failure(error)
+    }
+  }
+  
+  /// 수면 시간에 맞춘 DailySchedule을 불러옵니다.
+  /// - Returns: DailySchedule
+  func getDailyScheduleFromSleepTime() -> Result<DailySchedule, Error> {
+    let wakeupTime = appConfigRepository.fetchWakeupTime()
+    let bedTime = appConfigRepository.fetchBedTime()
+    
+    do {
+      let wakeup = try wakeupTime.get()
+      let bed = try bedTime.get()
+      
+      var timeSlots: [TimeSlot] = []
+      
+      for time in stride(from: 0, to: Time.hour * 24, by: Time.interval) {
+        timeSlots.append(TimeSlot(
+          start: time,
+          end: time + Time.interval,
+          isAvailable: wakeup <= time && time < bed - Time.interval ? true : false
+        ))
+      }
+      
+      return .success(DailySchedule(date: Date().formattedDate, timeSlots: timeSlots))
+    } catch {
+      return .failure(error)
+    }
   }
   
   /// 현재 시간대에 위치한 그룹화된 TimeSlot을 가져옵니다

--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -12,8 +12,11 @@ import Combine
 final class HomeViewModel {
   struct State {
     var timerCancellable: Cancellable?
+    
+    // TODO: CurrentTime 이름으로 초단위가 아닌 Date 타입으로 저장해보기
     var currentTimeInSeconds: Int = Date().totalSeconds
     
+    // TODO: SelectedDate로 네이밍 수정
     var currentDate: Date = Date().formattedDate
     
     // 탭바 상태
@@ -47,7 +50,6 @@ final class HomeViewModel {
     case .onAppear:
       handleTimer()
       initializeTimeSlot(date: state.currentDate)
-      print(try? dailyScheduleRepository.fetchAllDailySchedules().get())
     case .onDisappear:
       stopTimer()
       
@@ -84,26 +86,20 @@ private extension HomeViewModel {
     state.timerCancellable?.cancel()
   }
   
-  // TODO: 수정 필요
   func processTimerTask(date: Date) {
-    // 현재 선택된 날짜가 현재 날짜와 다른 경우 TimeSlot 업데이트
+    // 현재 시간(초) 업데이트
+    state.currentTimeInSeconds = date.totalSeconds
+    
+    // 다음 날짜로 넘어가는 시점인 경우 TimeSlot 업데이트
     if state.currentDate != date.formattedDate {
       initializeTimeSlot(date: date)
+      
+      // 현재 선택된 날짜 업데이트
+      state.currentDate = date.formattedDate
+    } else {
+      // 현재 위치한 TimeSlot만 업데이트
+      state.currentTimeSlot = getCurrentGroupedTimeSlot()
     }
-    
-    // 현재 선택된 날짜 업데이트
-    state.currentDate = date.formattedDate
-    
-    // 현재 시간(초) 업데이트
-    let currentSeconds = date.totalSeconds
-    state.currentTimeInSeconds = currentSeconds
-    
-    // 현재 위치한 타임 슬롯 업데이트
-    guard let currentTimeSlot = state.groupedTimeSlots.first(where: {
-      $0.start <= currentSeconds && currentSeconds < $0.end
-    }) else { return }
-    
-    state.currentTimeSlot = currentTimeSlot
   }
 }
 

--- a/TIG/Sources/Feature/Home/WeeklyCalendar.swift
+++ b/TIG/Sources/Feature/Home/WeeklyCalendar.swift
@@ -45,7 +45,7 @@ struct WeeklyCalendar: View {
         weekSlider = generateWeekSlider()
       }
     }
-    .onChange(of: homeViewModel.state.currentDate) {
+    .onChange(of: homeViewModel.state.selectedDate) {
       weekSlider = generateWeekSlider(anchor: $1)
     }
   }
@@ -113,7 +113,7 @@ private struct WeekView: View {
   @ViewBuilder
   private func dayView(_ date: Date) -> some View {
     let isSelected = date.isSameDate(
-      as: homeViewModel.state.currentDate
+      as: homeViewModel.state.selectedDate
     )
     
     VStack(spacing: 8) {
@@ -123,7 +123,7 @@ private struct WeekView: View {
         .font(.pretendard(size: 16, weight: .semiBold))
     }
     .foregroundStyle(
-      homeViewModel.state.currentDate == date
+      homeViewModel.state.selectedDate == date
       ? .gray01 : .gray05
     )
     .frame(maxWidth: .infinity, alignment: .center)

--- a/TIG/Sources/Feature/Home/WeeklyCalendar.swift
+++ b/TIG/Sources/Feature/Home/WeeklyCalendar.swift
@@ -11,10 +11,10 @@ struct WeeklyCalendar: View {
   let homeViewModel: HomeViewModel
   
   @State private var currentWeekIndex: Int = 1
+  @State private var weekSlider: [[Date.WeekDay]] = []
   
   var body: some View {
     TabView(selection: $currentWeekIndex) {
-      let weekSlider = homeViewModel.state.weekSlider
       ForEach(weekSlider.indices, id: \.self) { index in
         WeekView(
           homeViewModel: homeViewModel,
@@ -40,14 +40,55 @@ struct WeeklyCalendar: View {
     .tabViewStyle(.page(indexDisplayMode: .never))
     .frame(height: 60)
     .padding(.bottom, 19)
+    .onAppear {
+      if weekSlider.isEmpty {
+        weekSlider = generateWeekSlider()
+      }
+    }
+    .onChange(of: homeViewModel.state.currentDate) {
+      weekSlider = generateWeekSlider(anchor: $1)
+    }
   }
   
-  func paginateWeek() {
+  private func paginateWeek() {
     // 현재 WeekSlider의 중간 위치에 있을 경우는 업데이트 X
     if currentWeekIndex == 1 { return }
     
-    homeViewModel.send(.moveWeekPeriod(index: currentWeekIndex))
+    if weekSlider.indices.contains(currentWeekIndex) {
+      if let firstDate = weekSlider[currentWeekIndex].first?.date,
+         currentWeekIndex == 0 {
+        weekSlider.insert(firstDate.createPreviousWeek(), at: 0)
+        weekSlider.removeLast()
+      }
+      
+      if let lastDate = weekSlider[currentWeekIndex].last?.date,
+         currentWeekIndex == (weekSlider.count - 1) {
+        weekSlider.append(lastDate.createNextWeek())
+        weekSlider.removeFirst()
+      }
+    }
+    
     currentWeekIndex = 1
+  }
+  
+  /// 기준 날짜가 속한 주를 포함한 이전, 다음 주 데이터 묶음을 생성
+  /// - Parameter date: 기준이 되는 날짜
+  /// - Returns: 기준 날짜가 속한 주를 포함한 이전, 다음 주 데이터 묶음
+  private func generateWeekSlider(anchor date: Date = .now) -> [[Date.WeekDay]] {
+    var newWeeks = [[Date.WeekDay]]()
+    let anchorWeek = date.weekOfDate
+    
+    if let firstDate = anchorWeek.first?.date {
+      newWeeks.append(firstDate.createPreviousWeek())
+    }
+    
+    newWeeks.append(anchorWeek)
+    
+    if let lastDate = anchorWeek.last?.date {
+      newWeeks.append(lastDate.createNextWeek())
+    }
+    
+    return newWeeks
   }
 }
 

--- a/TIG/Sources/Model/Entity/TimeSlot.swift
+++ b/TIG/Sources/Model/Entity/TimeSlot.swift
@@ -30,53 +30,87 @@ struct GroupedTimeSlot {
 
 extension TimeSlot {
   static let mock: [TimeSlot] = [
+    // 00시 ~ 01시
     TimeSlot(start: 0, end: 30 * 60, isAvailable: true),
     TimeSlot(start: 30 * 60, end: 60 * 60, isAvailable: true),
+    // 01시 ~ 02시
     TimeSlot(start: 60 * 60, end: 90 * 60, isAvailable: true),
     TimeSlot(start: 90 * 60, end: 120 * 60, isAvailable: true),
+    // 02시 ~ 03시
     TimeSlot(start: 120 * 60, end: 150 * 60, isAvailable: true),
     TimeSlot(start: 150 * 60, end: 180 * 60, isAvailable: true),
+    // 03시 ~ 04시
     TimeSlot(start: 180 * 60, end: 210 * 60, isAvailable: true),
     TimeSlot(start: 210 * 60, end: 240 * 60, isAvailable: true),
+    // 04시 ~ 05시
     TimeSlot(start: 240 * 60, end: 270 * 60, isAvailable: true),
     TimeSlot(start: 270 * 60, end: 300 * 60, isAvailable: false),
+    // 05시 ~ 06시
     TimeSlot(start: 300 * 60, end: 330 * 60, isAvailable: false),
     TimeSlot(start: 330 * 60, end: 360 * 60, isAvailable: false),
+    // 06시 ~ 07시
     TimeSlot(start: 360 * 60, end: 390 * 60, isAvailable: false),
     TimeSlot(start: 390 * 60, end: 420 * 60, isAvailable: false),
+    // 07시 ~ 08시
     TimeSlot(start: 420 * 60, end: 450 * 60, isAvailable: false),
     TimeSlot(start: 450 * 60, end: 480 * 60, isAvailable: false),
+    // 08시 ~ 09시
     TimeSlot(start: 480 * 60, end: 510 * 60, isAvailable: false),
     TimeSlot(start: 510 * 60, end: 540 * 60, isAvailable: false),
+    // 09시 ~ 10시
     TimeSlot(start: 540 * 60, end: 570 * 60, isAvailable: true),
     TimeSlot(start: 570 * 60, end: 600 * 60, isAvailable: true),
+    // 10시 ~ 11시
     TimeSlot(start: 600 * 60, end: 630 * 60, isAvailable: true),
     TimeSlot(start: 630 * 60, end: 660 * 60, isAvailable: true),
+    // 11시 ~ 12시
     TimeSlot(start: 660 * 60, end: 690 * 60, isAvailable: true),
     TimeSlot(start: 690 * 60, end: 720 * 60, isAvailable: true),
+    // 12시 ~ 13시
     TimeSlot(start: 720 * 60, end: 750 * 60, isAvailable: true),
     TimeSlot(start: 750 * 60, end: 780 * 60, isAvailable: false),
+    // 13시 ~ 14시
     TimeSlot(start: 780 * 60, end: 810 * 60, isAvailable: false),
     TimeSlot(start: 810 * 60, end: 840 * 60, isAvailable: false),
+    // 14시 ~ 15시
     TimeSlot(start: 840 * 60, end: 870 * 60, isAvailable: false),
     TimeSlot(start: 870 * 60, end: 900 * 60, isAvailable: false),
+    // 15시 ~ 16시
     TimeSlot(start: 900 * 60, end: 930 * 60, isAvailable: false),
     TimeSlot(start: 930 * 60, end: 960 * 60, isAvailable: true),
+    // 16시 ~ 17시
     TimeSlot(start: 960 * 60, end: 990 * 60, isAvailable: true),
     TimeSlot(start: 990 * 60, end: 1020 * 60, isAvailable: true),
+    // 17시 ~ 18시
     TimeSlot(start: 1020 * 60, end: 1050 * 60, isAvailable: true),
     TimeSlot(start: 1050 * 60, end: 1080 * 60, isAvailable: false),
+    // 18시 ~ 19시
     TimeSlot(start: 1080 * 60, end: 1110 * 60, isAvailable: true),
     TimeSlot(start: 1110 * 60, end: 1140 * 60, isAvailable: true),
+    // 19시 ~ 20시
     TimeSlot(start: 1140 * 60, end: 1170 * 60, isAvailable: true),
     TimeSlot(start: 1170 * 60, end: 1200 * 60, isAvailable: true),
+    // 20시 ~ 21시
     TimeSlot(start: 1200 * 60, end: 1230 * 60, isAvailable: true),
     TimeSlot(start: 1230 * 60, end: 1260 * 60, isAvailable: true),
+    // 21시 ~ 22시
     TimeSlot(start: 1260 * 60, end: 1290 * 60, isAvailable: true),
     TimeSlot(start: 1290 * 60, end: 1320 * 60, isAvailable: true),
+    // 22시 ~ 23시
     TimeSlot(start: 1320 * 60, end: 1350 * 60, isAvailable: true),
     TimeSlot(start: 1350 * 60, end: 1380 * 60, isAvailable: true),
+    // 23시 ~ 24시
     TimeSlot(start: 1380 * 60, end: 1410 * 60, isAvailable: true),
     TimeSlot(start: 1410 * 60, end: 1440 * 60, isAvailable: true)
   ]
+}
+
+extension GroupedTimeSlot {
+  static let mock = GroupedTimeSlot(
+    start: 0,
+    end: 0,
+    isAvailable: false,
+    duration: 0,
+    count: 0
+  )
 }

--- a/TIG/Sources/Model/Entity/TimeSlot.swift
+++ b/TIG/Sources/Model/Entity/TimeSlot.swift
@@ -28,6 +28,20 @@ struct GroupedTimeSlot {
   var count: Int
 }
 
+extension Array where Element == GroupedTimeSlot {
+  /// 배열에서 현재 시간대에 위치한 TimeSlot 객체를 반환합니다. (빈 배열인 경우 mock 반환)
+  var currentTimeSlot: GroupedTimeSlot {
+    let now = Date()
+    let totalSeconds = now.totalSeconds
+    
+    return self.first(where: {
+      $0.start <= totalSeconds && $0.end > totalSeconds
+    }) ?? .mock
+  }
+}
+
+// MARK: - Mock Data
+
 extension TimeSlot {
   static let mock: [TimeSlot] = [
     // 00시 ~ 01시

--- a/TIG/Sources/Model/Entity/TimeSlot.swift
+++ b/TIG/Sources/Model/Entity/TimeSlot.swift
@@ -65,7 +65,7 @@ extension TimeSlot {
     TimeSlot(start: 960 * 60, end: 990 * 60, isAvailable: true),
     TimeSlot(start: 990 * 60, end: 1020 * 60, isAvailable: true),
     TimeSlot(start: 1020 * 60, end: 1050 * 60, isAvailable: true),
-    TimeSlot(start: 1050 * 60, end: 1080 * 60, isAvailable: true),
+    TimeSlot(start: 1050 * 60, end: 1080 * 60, isAvailable: false),
     TimeSlot(start: 1080 * 60, end: 1110 * 60, isAvailable: true),
     TimeSlot(start: 1110 * 60, end: 1140 * 60, isAvailable: true),
     TimeSlot(start: 1140 * 60, end: 1170 * 60, isAvailable: true),

--- a/TIG/Sources/Model/Entity/TimeSlot.swift
+++ b/TIG/Sources/Model/Entity/TimeSlot.swift
@@ -24,6 +24,7 @@ struct GroupedTimeSlot {
   var start: Int
   var end: Int
   var isAvailable: Bool
+  var duration: Int
   var count: Int
 }
 

--- a/TIG/Sources/Repository/Stub/StubAppConfigRepository.swift
+++ b/TIG/Sources/Repository/Stub/StubAppConfigRepository.swift
@@ -9,8 +9,8 @@ import Foundation
 
 final class StubAppConfigRepository: AppConfigRepository {
   private var onboardingCompleted: Bool = false
-  private var wakeupTime: Int = 0
-  private var bedTime: Int = 0
+  private var wakeupTime: Int = Time.hour * 6
+  private var bedTime: Int = Time.hour * 22
   
   func setOnboardingCompleted(wakeupTime: Int, bedTime: Int) {
     self.onboardingCompleted = true

--- a/TIG/Sources/Utility/Extension/Array+Ext.swift
+++ b/TIG/Sources/Utility/Extension/Array+Ext.swift
@@ -27,6 +27,7 @@ extension Array where Element == TimeSlot {
           start: currentStart,
           end: currentEnd,
           isAvailable: currentIsAvailable,
+          duration: currentEnd - currentStart,
           count: currentCount
         ))
         currentIsAvailable = self[index].isAvailable
@@ -40,6 +41,7 @@ extension Array where Element == TimeSlot {
       start: currentStart,
       end: currentEnd,
       isAvailable: currentIsAvailable,
+      duration: currentEnd - currentStart,
       count: currentCount
     ))
     

--- a/TIG/Sources/Utility/Extension/Date+Ext.swift
+++ b/TIG/Sources/Utility/Extension/Date+Ext.swift
@@ -26,6 +26,10 @@ extension Date {
     return Self.configuredCalendar.component(.day, from: self)
   }
   
+  var weekday: Int {
+    return Self.configuredCalendar.component(.weekday, from: self)
+  }
+  
   /// 오늘 날짜인지 확인
   var isToday: Bool {
     Self.configuredCalendar.isDateInToday(self)

--- a/TIG/Sources/Utility/Extension/Int+Ext.swift
+++ b/TIG/Sources/Utility/Extension/Int+Ext.swift
@@ -41,8 +41,13 @@ extension Int {
   private func getDurationFormat(from totalSeconds: Int) -> String {
     let hours = totalSeconds / Time.hour
     let minutes = totalSeconds % Time.hour / Time.minute
-    if minutes == 0 {
-      return "\(hours)시간"  // 0분일 경우 생략
+    
+    if hours == 0 && minutes == 0 {
+      return "0시간 0분"
+    } else if hours == 0 {
+      return "\(minutes)분"
+    } else if minutes == 0 {
+      return "\(hours)시간"
     } else {
       return "\(hours)시간 \(minutes)분"
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 번호를 작성해 주세요 -->
<!-- ex) - close #1 -->
- close #15 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요(이미지 첨부 가능) --> 
홈/가용시간 화면에 적용될 로직들을 구현했습니다.
- 타이머 구현 (현재 시간에 맞는 가용시간 정보 보여주기)
- 선택된 날짜에 맞는 타임슬롯 배열 가져오기

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해 주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->
|기능|스크린샷|
|:--:|:--:|
|가용시간|<img src = "https://github.com/user-attachments/assets/41034765-4f94-4e27-9eeb-4f8ff7413629" width ="250">|
|비가용시간 & 마지막 타임슬롯이 아님|<img src = "https://github.com/user-attachments/assets/a0777f90-7c21-4df3-84f7-099f16d32c0d" width ="250">|
|비가용시간 & 마지막 타임슬롯임|<img src = "https://github.com/user-attachments/assets/0388c0ca-2386-4dc4-9c3b-97c16225cb95" width ="250">|


## 💬 추가 설명
<!-- 추가적으로 설명할 부분이 있다면 작성해 주세요 -->
View에 대한 코드는 굳이 안읽으셔도 됩니다. (선택!)
ViewModel 부분만 확인해주세여.