### PR TITLE
[Feature] 시간 편집 기능 구현

### DIFF
--- a/TIG/Sources/Feature/Home/HomeViewModel.swift
+++ b/TIG/Sources/Feature/Home/HomeViewModel.swift
@@ -38,6 +38,9 @@ final class HomeViewModel {
     
     // 탭바 액션
     case changeTab(HomeTab)
+    
+    // 시간 수정 액션
+    case dailyTimeSaveTapped([TimeSlot])
   }
   
   private(set) var state: State = .init()
@@ -72,6 +75,9 @@ final class HomeViewModel {
       
     case .changeTab(let tab):
       state.selectedTab = tab
+      
+    case .dailyTimeSaveTapped(let timeSlots):
+      updateTimeSlot(date: state.selectedDate, timeSlots: timeSlots)
     }
   }
 }
@@ -187,5 +193,18 @@ private extension HomeViewModel {
     } catch {
       return .failure(error)
     }
+  }
+  
+  /// TimeSlots을 업데이트 합니다.
+  /// - Parameters:
+  ///   - date: 업데이트할 날짜.
+  ///   - timeSlots: 해당 일정에 적용할 `TimeSlot` 배열.
+  func updateTimeSlot(date: Date, timeSlots: [TimeSlot]) {
+    dailyScheduleRepository.updateDailySchedule(
+      date: state.selectedDate,
+      timeSlots: timeSlots
+    )
+    state.groupedTimeSlots = timeSlots.groupedTimeSlots
+    state.timeSlots = timeSlots
   }
 }

--- a/TIG/Sources/Feature/Home/TotalTime/TotalTimeView.swift
+++ b/TIG/Sources/Feature/Home/TotalTime/TotalTimeView.swift
@@ -17,12 +17,14 @@ struct TotalTimeView: View {
     }
     .padding(.horizontal, 20)
     .scrollIndicators(.hidden)
-    .onAppear {
-      homeViewModel.send(.onAppear)
-    }
   }
 }
 
 #Preview {
-  TotalTimeView(homeViewModel: HomeViewModel())
+  let homeViewModel = HomeViewModel()
+  
+  TotalTimeView(homeViewModel: homeViewModel)
+    .onAppear {
+      homeViewModel.send(.onAppear)
+    }
 }

--- a/TIG/Sources/Feature/More/EditTimeView.swift
+++ b/TIG/Sources/Feature/More/EditTimeView.swift
@@ -10,8 +10,13 @@ import SwiftUI
 struct EditTimeView: View {
   
   @Environment(\.dismiss) var dismiss
-  @State var timeSlots: [TimeSlot] = TimeSlot.mock
+  @State var timeSlots: [TimeSlot]
   let homeViewModel: HomeViewModel
+  
+  init(homeViewModel: HomeViewModel) {
+    self.homeViewModel = homeViewModel
+    self.timeSlots = homeViewModel.state.timeSlots
+  }
   
   var body: some View {
     
@@ -44,13 +49,15 @@ struct EditTimeView: View {
         
         ToolbarItem(placement: .navigationBarTrailing) {
           navigationButton(title: "저장") {
-            print("hello")
+            homeViewModel.send(.dailyTimeSaveTapped(timeSlots))
+            self.dismiss()
           }
         }
       }
     }
   }
   
+  // MARK: (F)navigationButton
   @ViewBuilder
   private func navigationButton(
     title: String,

--- a/TIG/Sources/Repository/Impl/DailyScheduleRepositoryImpl.swift
+++ b/TIG/Sources/Repository/Impl/DailyScheduleRepositoryImpl.swift
@@ -16,11 +16,10 @@ final class DailyScheduleRepositoryImpl: DailyScheduleRepository {
     self.modelContext = modelContext
   }
   
-  
   func createDailySchedule(_ dailySchedule: DailySchedule) {
     print("Impl:", #function)
-    
-    let result = findDailySchedule(dailySchedule)
+    let date = dailySchedule.date
+    let result = findDailyScheduleByDate(date)
     switch result {
     case .success:
       print(SwiftDataError.modelAlreadyExist)
@@ -66,12 +65,12 @@ final class DailyScheduleRepositoryImpl: DailyScheduleRepository {
 
   
   func updateDailySchedule(
-    dailySchedule: DailySchedule,
+    date: Date,
     timeSlots: [TimeSlot]
   ) {
     print("Impl:", #function)
     
-    let result = findDailySchedule(dailySchedule)
+    let result = findDailyScheduleByDate(date)
     
     switch result {
     case .success(let model):
@@ -85,8 +84,8 @@ final class DailyScheduleRepositoryImpl: DailyScheduleRepository {
   
   func deleteDailySchedule(_ dailySchedule: DailySchedule) {
     print("Impl:", #function)
-    
-    let result = findDailySchedule(dailySchedule)
+    let date = dailySchedule.date
+    let result = findDailyScheduleByDate(date)
     
     switch result {
     case .success(let model):
@@ -99,11 +98,10 @@ final class DailyScheduleRepositoryImpl: DailyScheduleRepository {
 }
 
 extension DailyScheduleRepositoryImpl {
-  private func findDailySchedule(
-    _ dailySchedule: DailySchedule
+  private func findDailyScheduleByDate(
+    _ date: Date
   ) -> Result<DailyScheduleDTO, SwiftDataError> {
     print("Impl:", #function)
-    let date = dailySchedule.date
     let predicate = #Predicate<DailyScheduleDTO> { $0.date == date }
     let descriptor = FetchDescriptor(predicate: predicate)
     

--- a/TIG/Sources/Repository/Interface/DailyScheduleRepository.swift
+++ b/TIG/Sources/Repository/Interface/DailyScheduleRepository.swift
@@ -23,9 +23,9 @@ protocol DailyScheduleRepository {
   
   /// 기존 일정을 업데이트합니다.
   /// - Parameters:
-  ///   - dailySchedule: 업데이트할 `DailySchedule` 객체.
+  ///   - date: 업데이트할 날짜.
   ///   - timeSlots: 해당 일정에 적용할 `TimeSlot` 배열.
-  func updateDailySchedule(dailySchedule: DailySchedule, timeSlots: [TimeSlot])
+  func updateDailySchedule(date: Date, timeSlots: [TimeSlot])
   
   /// 특정 일정을 삭제합니다.
   /// - Parameter dailySchedule: 삭제할 `DailySchedule` 객체.

--- a/TIG/Sources/Repository/Stub/StubDailyScheduleRepository.swift
+++ b/TIG/Sources/Repository/Stub/StubDailyScheduleRepository.swift
@@ -24,11 +24,11 @@ final class StubDailyScheduleRepository: DailyScheduleRepository {
   }
   
   func updateDailySchedule(
-    dailySchedule: DailySchedule,
+    date: Date,
     timeSlots: [TimeSlot]
   ) {
     if let index = dailySchedules.firstIndex(
-      where: { $0.date == dailySchedule.date }
+      where: { $0.date == date }
     ) {
       var updatedSchedule = dailySchedules[index]
       updatedSchedule.timeSlots = timeSlots


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 번호를 작성해 주세요 -->
<!-- ex) - close #1 -->
- close #22 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요(이미지 첨부 가능) --> 
시간 편집 기능을 구현하였습니다.

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해 주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->

https://github.com/user-attachments/assets/9081e6db-4b78-4848-a259-628d72c748ee


## 💬 추가 설명
<!-- 추가적으로 설명할 부분이 있다면 작성해 주세요 -->
### 1. DailyScheduleRepository 수정
기존에는 timeSlots을 업데이트 하려면 updateDailySchedule의 파라미터로 dailySchedule 객체를 받아야 했는데
ViewModel에서 굳이 dailySchedule의 객체를 가지고 있을 필요가 없는것 같아서 date 파라미터를 받아서 업데이트할 수 있게 레포지토리를 수정하였습니다.

### 2. TimeSlot 업데이트 함수
ViewModel에 작성된 업데이트 함수는 다음과 같습니다.
나중에 Weekly에서 시간 수정시에도 쓸 수 있을 것 같아 date를 파라미터로 받게 하여 따로 뺐습니다.
```swift
  /// TimeSlots을 업데이트 합니다.
  /// - Parameters:
  ///   - date: 업데이트할 날짜.
  ///   - timeSlots: 해당 일정에 적용할 `TimeSlot` 배열.
  func updateTimeSlot(date: Date, timeSlots: [TimeSlot]) {
    dailyScheduleRepository.updateDailySchedule(
      date: state.selectedDate,
      timeSlots: timeSlots
    )
    state.groupedTimeSlots = timeSlots.groupedTimeSlots
    state.timeSlots = timeSlots
  }
```
