### PR TITLE
[Feature] 반복 일정 관리&수정 뷰 구현

### DIFF
--- a/TIG/Sources/Feature/Common/GroupedTimeSlots.swift
+++ b/TIG/Sources/Feature/Common/GroupedTimeSlots.swift
@@ -12,7 +12,7 @@ struct GroupedTimeSlots: View {
   let groupedTimeSlots: [GroupedTimeSlot]
   
   var body: some View {
-    HStack(alignment: .top, spacing: 18) {
+    HStack(alignment: .top, spacing: 17) {
       TimeIndicator()
       
       VStack(alignment: .leading, spacing: SlotLayout.space * 2) {
@@ -71,7 +71,7 @@ private struct AvailableSlot: View {
     .frame(height: SlotLayout.groupedHeight(for: slotCount))
     .background(
       RoundedRectangle(cornerRadius: 8)
-        .foregroundStyle(.blueTimeSlot)
+        .foregroundStyle(.primaryNeutral)
     )
   }
   

--- a/TIG/Sources/Feature/Common/SelectableTimeSlots.swift
+++ b/TIG/Sources/Feature/Common/SelectableTimeSlots.swift
@@ -24,7 +24,7 @@ struct SelectableTimeSlots: View {
         TimeIndicator()
         TimeSlots(timeSlots: $timeSlots)
       }
-    }
+    }.padding(.bottom, 29)
   }
   
   @ViewBuilder
@@ -52,7 +52,6 @@ private struct TimeSlots: View {
       ForEach($timeSlots) { $timeSlot in
         Button {
           timeSlot.isAvailable.toggle()
-          print(timeSlot)
         } label: {
           RoundedRectangle(cornerRadius: 8)
             .strokeBorder(

--- a/TIG/Sources/Feature/Home/HomeView.swift
+++ b/TIG/Sources/Feature/Home/HomeView.swift
@@ -78,7 +78,7 @@ struct HomeView: View {
   private var menuButton: some View {
     Menu {
       NavigationLink {
-        WeeklyRepeatView()
+        WeeklyRepeatView(homeViewModel: homeViewModel)
       } label: {
         Label(
           "반복 관리",

--- a/TIG/Sources/Feature/More/EditTimeView.swift
+++ b/TIG/Sources/Feature/More/EditTimeView.swift
@@ -41,13 +41,13 @@ struct EditTimeView: View {
       .navigationBarTitleDisplayMode(.inline)
       .scrollIndicators(.hidden)
       .toolbar {
-        ToolbarItem(placement: .navigationBarLeading) {
+        ToolbarItem(placement: .topBarLeading) {
           navigationButton(title: "취소") {
             self.dismiss()
           }
         }
         
-        ToolbarItem(placement: .navigationBarTrailing) {
+        ToolbarItem(placement: .topBarTrailing) {
           navigationButton(title: "저장") {
             homeViewModel.send(.dailyTimeSaveTapped(timeSlots))
             self.dismiss()

--- a/TIG/Sources/Feature/More/WeeklyRepeatView.swift
+++ b/TIG/Sources/Feature/More/WeeklyRepeatView.swift
@@ -8,11 +8,119 @@
 import SwiftUI
 
 struct WeeklyRepeatView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  @State var selectedDay: WeekDay = .sun
+  @State var isEditMode = false
+  
+  let homeViewModel: HomeViewModel
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      WeeklyHeader(selectedDay: $selectedDay)
+        
+      DayPageView(selectedDay: $selectedDay, isEditMode: $isEditMode)
     }
+    .background(.backgroundNormal)
+    .navigationTitle(isEditMode ? "반복 일정 수정" : "반복 일정 관리")
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .topBarTrailing) {
+        Button {
+          isEditMode.toggle()
+        } label: {
+          Text(isEditMode ? "저장" : "수정")
+            .foregroundStyle(.primaryNormal)
+            .font(.pretendard(size: 16, weight: .medium))
+        }
+      }
+    }
+  }
+}
+
+// MARK: - (S)WeeklyHeader
+private struct WeeklyHeader: View {
+  
+  @Binding var selectedDay: WeekDay
+  
+  var body: some View {
+    HStack {
+      ForEach(WeekDay.allCases, id: \.self) { day in
+        Text(day.text)
+          .frame(maxWidth: .infinity)
+          .foregroundStyle(
+            day == selectedDay ? .contentException : .contentNormal
+          )
+          .font(
+            .pretendard(
+              size: 14,
+              weight: day == selectedDay ? .semiBold : .medium
+            )
+          )
+          .onTapGesture {
+            selectedDay = day
+          }
+          .background(
+            Circle()
+              .fill(day == selectedDay ? .primaryNormal : .clear)
+              .frame(width: 42, height: 42)
+              .scaleEffect(selectedDay != day ? 0.85 : 1.0)
+              .animation(.easeInOut(duration: 0.2), value: selectedDay)
+          )
+      }
+    }
+    .padding(26)
+  }
+}
+
+
+// MARK: - (S)DayPageView
+private struct DayPageView: View {
+  
+  @Binding var selectedDay: WeekDay
+  @Binding var isEditMode: Bool
+  
+  var body: some View {
+    TabView(selection: $selectedDay) {
+      ForEach(WeekDay.allCases, id: \.self) { day in
+        DaySlotView(isEditMode: $isEditMode)
+          .tag(day)
+      }
+    }
+    .background(.backgroundAlternative)
+    .animation(.default, value: selectedDay)
+    .ignoresSafeArea()
+    .tabViewStyle(.page(indexDisplayMode: .never))
+  }
+}
+
+// MARK: - (S)DaySlotView
+private struct DaySlotView: View {
+  
+  @Binding var isEditMode: Bool
+  @State var timeSlots = TimeSlot.mock
+  
+  var body: some View {
+    ScrollView {
+      VStack {
+        if isEditMode {
+          SelectableTimeSlots(timeSlots: $timeSlots)
+            .padding(.top, 16)
+        } else {
+          GroupedTimeSlots(
+            groupedTimeSlots: TimeSlot.mock.groupedTimeSlots
+          ).padding(.top, 18)
+        }
+      }
+      .padding(.horizontal, 20)
+      .background(.backgroundNormal)
+      .padding(.top, 5)
+    }
+    .ignoresSafeArea()
+    .scrollIndicators(.hidden)
+  }
 }
 
 #Preview {
-    WeeklyRepeatView()
+  NavigationStack {
+    WeeklyRepeatView(homeViewModel: HomeViewModel())
+  }
 }

--- a/TIG/Sources/Feature/More/WeeklyRepeatView.swift
+++ b/TIG/Sources/Feature/More/WeeklyRepeatView.swift
@@ -16,10 +16,10 @@ struct WeeklyRepeatView: View {
   var body: some View {
     VStack(spacing: 0) {
       WeeklyHeader(selectedDay: $selectedDay)
-        
+      
       DayPageView(selectedDay: $selectedDay, isEditMode: $isEditMode)
     }
-    .background(.backgroundNormal)
+    .background(.backgroundAlternative)
     .navigationTitle(isEditMode ? "반복 일정 수정" : "반복 일정 관리")
     .navigationBarTitleDisplayMode(.inline)
     .toolbar {
@@ -68,6 +68,8 @@ private struct WeeklyHeader: View {
       }
     }
     .padding(26)
+    .background(.backgroundNormal)
+    .padding(.bottom, 5)
   }
 }
 
@@ -77,26 +79,43 @@ private struct DayPageView: View {
   
   @Binding var selectedDay: WeekDay
   @Binding var isEditMode: Bool
+  @State var weeklyTimeSlots: [WeekDay: [TimeSlot]] = [
+    .sun: TimeSlot.mock,
+    .mon: TimeSlot.mock,
+    .tue: TimeSlot.mock,
+    .wed: TimeSlot.mock,
+    .thu: TimeSlot.mock,
+    .fri: TimeSlot.mock,
+    .sat: TimeSlot.mock,
+  ]
   
   var body: some View {
     TabView(selection: $selectedDay) {
       ForEach(WeekDay.allCases, id: \.self) { day in
-        DaySlotView(isEditMode: $isEditMode)
+        TimeSlotsView(isEditMode: $isEditMode, timeSlots: binding(for: day))
           .tag(day)
       }
     }
-    .background(.backgroundAlternative)
-    .animation(.default, value: selectedDay)
+    .background(.backgroundNormal)
     .ignoresSafeArea()
+    .animation(.spring(duration: 2), value: selectedDay)
     .tabViewStyle(.page(indexDisplayMode: .never))
+  }
+  
+  // 요일에 해당하는 타임 슬롯 배열을 바인딩으로 반환해주는 함수
+  private func binding(for key: WeekDay) -> Binding<[TimeSlot]> {
+    return Binding(
+      get: { return self.weeklyTimeSlots[key] ?? [] },
+      set: { self.weeklyTimeSlots[key] = $0 }
+    )
   }
 }
 
-// MARK: - (S)DaySlotView
-private struct DaySlotView: View {
+// MARK: - (S)TimeSlotsView
+private struct TimeSlotsView: View {
   
   @Binding var isEditMode: Bool
-  @State var timeSlots = TimeSlot.mock
+  @Binding var timeSlots: [TimeSlot]
   
   var body: some View {
     ScrollView {
@@ -106,13 +125,11 @@ private struct DaySlotView: View {
             .padding(.top, 16)
         } else {
           GroupedTimeSlots(
-            groupedTimeSlots: TimeSlot.mock.groupedTimeSlots
-          ).padding(.top, 18)
+            groupedTimeSlots: timeSlots.groupedTimeSlots
+          ).padding(.top, 19)
         }
       }
       .padding(.horizontal, 20)
-      .background(.backgroundNormal)
-      .padding(.top, 5)
     }
     .ignoresSafeArea()
     .scrollIndicators(.hidden)


### PR DESCRIPTION
## #️⃣ 연관된 이슈
<!-- 이슈 번호를 작성해 주세요 -->
<!-- ex) - close #1 -->
- close #24 

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해 주세요(이미지 첨부 가능) --> 
반복 일정 관리&수정 뷰를 구현하였습니다.

## 🎨 스크린샷
<!-- UI 변경사항이 있는 경우 스크린샷을 첨부해 주세요. -->
<!-- img src "이부분에 gif파일 넣어주세요" -->

https://github.com/user-attachments/assets/c92f00aa-5f02-4058-9e4d-2cae66691dc7

## 💬 추가 설명
<!-- 추가적으로 설명할 부분이 있다면 작성해 주세요 -->
코드가 짧습니다. 현재 mock 데이터로 넣어놨지만 머지되면 바로 이슈파서 기능 구현을 할 예정입니다 !
뷰를 구현해보면서 생각해보았는데,, WeeklySchedule을 fetch하는 코드가 추가 되면
HomeViewModel의 코드량이 늘어날 것 같은데 WeeklyRepeatViewModel을 만들어서 하는건 어떤지 의견이 궁금합니다.
